### PR TITLE
Added MSVC 2013 support; Proper check of CPU's AVX2 feature support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@ lib/libbase64.o
 test/benchmark
 test/test_base64
 test/*.o
+*.vcxproj*.user
+*.suo
+*.sdf
+*.opensdf
+*.pdb
+*.ncb
+msvc/base64
+msvc/benchmark_base64
+msvc/test_base64

--- a/lib/codec_choose.c
+++ b/lib/codec_choose.c
@@ -1,7 +1,40 @@
 #include <stddef.h>
 
-#if __x86_64__ || __i386__
-#include <cpuid.h>
+#if __x86_64__ || __i386__ || _M_X86 || _M_X64
+	#ifdef _MSC_VER
+		#include <intrin.h>
+		#define __cpuid_count(__level, __count, __eax, __ebx, __ecx, __edx) \
+		{\
+			int info[4];\
+			__cpuidex(info, __level, __count);\
+			__eax = info[0];\
+			__ebx = info[1];\
+			__ecx = info[2];\
+			__edx = info[3];\
+		}
+		#define __cpuid(__level, __eax, __ebx, __ecx, __edx)\
+		{\
+			int info[4];\
+			__cpuidex(info, __level, 0);\
+			__eax = info[0];\
+			__ebx = info[1];\
+			__ecx = info[2];\
+			__edx = info[3];\
+		}
+	#else
+		#include <cpuid.h>
+		#if __GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 4
+		inline unsigned long  _xgetbv_32(unsigned int index){
+			unsigned int eax, edx;
+			__asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+			return eax;
+
+		}
+		#else
+			#define _xgetbv_32() 0
+		#endif
+	#endif
+
 #ifndef bit_AVX2
 #define bit_AVX2 (1 << 5)
 #endif
@@ -9,6 +42,10 @@
 #define bit_SSSE3 (1 << 9)
 #endif
 #endif
+
+#define bit_XSAVE_XRSTORE (1 << 27)
+
+
 
 #include "../include/libbase64.h"
 #include "codecs.h"
@@ -90,18 +127,41 @@ codec_choose_arm (struct codec *codec)
 static int
 codec_choose_x86 (struct codec *codec)
 {
-#if (__x86_64__ || __i386__) && (HAVE_AVX2 || HAVE_SSSE3)
+#if (__x86_64__ || __i386__ || _M_X86 || _M_X64 ) && (HAVE_AVX2 || HAVE_SSSE3)
 
 	unsigned int eax, ebx = 0, ecx = 0, edx;
-	unsigned int max_level = __get_cpuid_max(0, NULL);
+	unsigned int max_level;
+
+	#ifdef _MSC_VER 
+	int info[4];
+	__cpuidex(info, 0, 0);
+	max_level = info[0];
+	#else
+	max_level = __get_cpuid_max(0, NULL);
+	#endif
 
 	#if HAVE_AVX2
-	/* Check for AVX2 support: */
+	/* Check for AVX2 support: 
+	 Checking for AVX requires 3 things:
+	 1) CPUID indicates that the OS uses XSAVE and XRSTORE
+	     instructions (allowing saving YMM registers on context
+	     switch)
+	 2) CPUID indicates support for AVX
+	 3) XGETBV indicates the AVX registers will be saved and
+	     restored on context switch
+	
+	 Note that XGETBV is only available on 686 or later CPUs, so
+	 the instruction needs to be conditionally run.*/
 	if (max_level >= 7) {
 		__cpuid_count(7, 0, eax, ebx, ecx, edx);
-		if (ebx & bit_AVX2) {
-			codec->enc = base64_stream_encode_avx2;
-			codec->dec = base64_stream_decode_avx2;
+
+		if ( (ebx & bit_AVX2) && (ecx & bit_XSAVE_XRSTORE)) {
+			unsigned long long xcrFeatureMask;
+			xcrFeatureMask = _xgetbv_32(0);
+			if ( xcrFeatureMask & 0x6 ) {
+				codec->enc = base64_stream_encode_avx2;
+				codec->dec = base64_stream_decode_avx2;
+			}
 			return 1;
 		}
 	}

--- a/lib/dec/avx2.c
+++ b/lib/dec/avx2.c
@@ -36,11 +36,11 @@ while (srclen >= 45)
 
 	/* Check if all bytes have been classified; else fall back on bytewise code
 	 * to do error checking and reporting: */
-	if ((unsigned int)_mm256_movemask_epi8(s1mask | s2mask | s3mask | s4mask | s5mask) != 0xFFFFFFFF) {
+	if ((unsigned int)_mm256_movemask_epi8(_mm256_or_si256(_mm256_or_si256(_mm256_or_si256(_mm256_or_si256(s1mask, s2mask), s3mask), s4mask), s5mask)) != 0xFFFFFFFF) {
 		break;
 	}
 	/* Subtract sets from byte values: */
-	res = _mm256_sub_epi8(str, _mm256_set1_epi8('A')) & s1mask;
+	res = _mm256_and_si256(_mm256_sub_epi8(str, _mm256_set1_epi8('A')) , s1mask);
 	res = _mm256_blendv_epi8(res, _mm256_sub_epi8(str, _mm256_set1_epi8('a' - 26)), s2mask);
 	res = _mm256_blendv_epi8(res, _mm256_sub_epi8(str, _mm256_set1_epi8('0' - 52)), s3mask);
 	res = _mm256_blendv_epi8(res, _mm256_set1_epi8(62), s4mask);
@@ -62,16 +62,16 @@ while (srclen >= 45)
 	mask = _mm256_set1_epi32(0x3F000000);
 
 	/* Pack bytes together: */
-	str = _mm256_slli_epi32(res & mask, 2);
+	str = _mm256_slli_epi32(_mm256_and_si256(res , mask), 2);
 	mask = _mm256_srli_epi32(mask, 8);
 
-	str |= _mm256_slli_epi32(res & mask, 4);
+	str = _mm256_or_si256(str, _mm256_slli_epi32(_mm256_and_si256(res, mask), 4));
 	mask = _mm256_srli_epi32(mask, 8);
 
-	str |= _mm256_slli_epi32(res & mask, 6);
+	str = _mm256_or_si256(str, _mm256_slli_epi32(_mm256_and_si256(res , mask), 6));
 	mask = _mm256_srli_epi32(mask, 8);
 
-	str |= _mm256_slli_epi32(res & mask, 8);
+	str = _mm256_or_si256(str,_mm256_slli_epi32(_mm256_and_si256(res, mask), 8));
 
 	/* As in AVX2 encoding, we have to shuffle and repack each 128-bit lane
 	 * separately due to the way _mm256_shuffle_epi8 works: */

--- a/lib/enc/avx2.c
+++ b/lib/enc/avx2.c
@@ -25,20 +25,20 @@ while (srclen >= 32)
 	mask = _mm256_set1_epi32(0x3F000000);
 
 	/* Shift bits by 2, mask in only the first byte: */
-	res = _mm256_srli_epi32(str, 2) & mask;
+	res = _mm256_and_si256(_mm256_srli_epi32(str, 2), mask);
 	mask = _mm256_srli_epi32(mask, 8);
 
 	/* Shift bits by 4, mask in only the second byte: */
-	res |= _mm256_srli_epi32(str, 4) & mask;
+	res = _mm256_or_si256(res,_mm256_and_si256(_mm256_srli_epi32(str, 4), mask));
 	mask = _mm256_srli_epi32(mask, 8);
 
 	/* Shift bits by 6, mask in only the third byte: */
-	res |= _mm256_srli_epi32(str, 6) & mask;
+	res = _mm256_or_si256(res, _mm256_and_si256(_mm256_srli_epi32(str, 6) , mask));
 	mask = _mm256_srli_epi32(mask, 8);
 
 	/* No shift necessary for the fourth byte because we duplicated
 	 * the third byte to this position; just mask: */
-	res |= str & mask;
+	res = _mm256_or_si256(res, _mm256_and_si256(str, mask));
 
 	/* Reorder to 32-bit little-endian: */
 	res = _mm256_shuffle_epi8(res,
@@ -62,21 +62,21 @@ while (srclen >= 32)
 
 	/* set 4: 62, "+" */
 	s4mask = _mm256_cmpeq_epi8(res, _mm256_set1_epi8(62));
-	blockmask |= s4mask;
+	blockmask = _mm256_or_si256(blockmask, s4mask);
 
 	/* set 3: 52..61, "0123456789" */
 	s3mask = _mm256_andnot_si256(blockmask, _mm256_cmpgt_epi8(res, _mm256_set1_epi8(51)));
-	blockmask |= s3mask;
+	blockmask = _mm256_or_si256(blockmask, s3mask);
 
 	/* set 2: 26..51, "abcdefghijklmnopqrstuvwxyz" */
 	s2mask = _mm256_andnot_si256(blockmask, _mm256_cmpgt_epi8(res, _mm256_set1_epi8(25)));
-	blockmask |= s2mask;
+	blockmask = _mm256_or_si256(blockmask, s2mask);
 
 	/* set 1: 0..25, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	 * Everything that is not blockmasked */
 
 	/* Create the masked character sets: */
-	str = _mm256_set1_epi8('/') & s5mask;
+	str = _mm256_and_si256(_mm256_set1_epi8('/') , s5mask);
 	str = _mm256_blendv_epi8(str, _mm256_set1_epi8('+'), s4mask);
 	str = _mm256_blendv_epi8(str, _mm256_add_epi8(res, _mm256_set1_epi8('0' - 52)), s3mask);
 	str = _mm256_blendv_epi8(str, _mm256_add_epi8(res, _mm256_set1_epi8('a' - 26)), s2mask);

--- a/msvc/base64.sln
+++ b/msvc/base64.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40418.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "base64", "base64.vcxproj", "{77366EC8-57F1-4124-834E-3A0CECCF3CC9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_base64", "test_base64.vcxproj", "{A2E93EA6-3F4A-4859-A4B5-0DBE1EEC68EA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{77366EC8-57F1-4124-834E-3A0CECCF3CC9} = {77366EC8-57F1-4124-834E-3A0CECCF3CC9}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "benchmark_base64", "benchmark_base64.vcxproj", "{1D13F620-C116-4CB2-AED8-9EB3E4F139C1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{77366EC8-57F1-4124-834E-3A0CECCF3CC9} = {77366EC8-57F1-4124-834E-3A0CECCF3CC9}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{77366EC8-57F1-4124-834E-3A0CECCF3CC9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{77366EC8-57F1-4124-834E-3A0CECCF3CC9}.Debug|Win32.Build.0 = Debug|Win32
+		{77366EC8-57F1-4124-834E-3A0CECCF3CC9}.Release|Win32.ActiveCfg = Release|Win32
+		{77366EC8-57F1-4124-834E-3A0CECCF3CC9}.Release|Win32.Build.0 = Release|Win32
+		{A2E93EA6-3F4A-4859-A4B5-0DBE1EEC68EA}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A2E93EA6-3F4A-4859-A4B5-0DBE1EEC68EA}.Debug|Win32.Build.0 = Debug|Win32
+		{A2E93EA6-3F4A-4859-A4B5-0DBE1EEC68EA}.Release|Win32.ActiveCfg = Release|Win32
+		{A2E93EA6-3F4A-4859-A4B5-0DBE1EEC68EA}.Release|Win32.Build.0 = Release|Win32
+		{1D13F620-C116-4CB2-AED8-9EB3E4F139C1}.Debug|Win32.ActiveCfg = Debug|Win32
+		{1D13F620-C116-4CB2-AED8-9EB3E4F139C1}.Debug|Win32.Build.0 = Debug|Win32
+		{1D13F620-C116-4CB2-AED8-9EB3E4F139C1}.Release|Win32.ActiveCfg = Release|Win32
+		{1D13F620-C116-4CB2-AED8-9EB3E4F139C1}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/msvc/base64.vcxproj
+++ b/msvc/base64.vcxproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{77366EC8-57F1-4124-834E-3A0CECCF3CC9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;__SSSE3__;__AVX2__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;__SSSE3__;__AVX2__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\lib\codec_avx2.c" />
+    <ClCompile Include="..\lib\codec_choose.c" />
+    <ClCompile Include="..\lib\codec_neon32.c" />
+    <ClCompile Include="..\lib\codec_neon64.c" />
+    <ClCompile Include="..\lib\codec_plain.c" />
+    <ClCompile Include="..\lib\codec_ssse3.c" />
+    <ClCompile Include="..\lib\lib.c" />
+    <ClCompile Include="..\test\codec_supported.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\libbase64.h" />
+    <ClInclude Include="..\lib\codecs.h" />
+    <ClInclude Include="..\test\codec_supported.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/base64.vcxproj.filters
+++ b/msvc/base64.vcxproj.filters
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\lib\codec_avx2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lib\codec_choose.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lib\codec_plain.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lib\codec_ssse3.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lib\lib.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\test\codec_supported.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lib\codec_neon32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lib\codec_neon64.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\libbase64.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\lib\codecs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\test\codec_supported.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/msvc/benchmark_base64.vcxproj
+++ b/msvc/benchmark_base64.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1D13F620-C116-4CB2-AED8-9EB3E4F139C1}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>benchmark_base64</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\base64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>base64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(SolutionDir)\base64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>base64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\test\benchmark.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/benchmark_base64.vcxproj.filters
+++ b/msvc/benchmark_base64.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\test\benchmark.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/msvc/config.h
+++ b/msvc/config.h
@@ -1,0 +1,4 @@
+#define HAVE_AVX2   1
+#define HAVE_NEON32 0
+#define HAVE_NEON64 0
+#define HAVE_SSSE3  1

--- a/msvc/test_base64.vcxproj
+++ b/msvc/test_base64.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A2E93EA6-3F4A-4859-A4B5-0DBE1EEC68EA}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>test_base64</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>base64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\base64\Debug;$(SolutionDir)\Test;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>base64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\base64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\test\test_base64.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/test_base64.vcxproj.filters
+++ b/msvc/test_base64.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\test\test_base64.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Added Visual Studio solution.
Tests passed.
Could not run AVX2 test on unix because VirtualBox has no support for AVX instructions.

![screenshot 2015-09-04 001.png](https://lh3.googleusercontent.com/-AjI2fdEa-I8/Velc5Krsl7I/AAAAAAAAGu4/uSY6-uazJ34/s0/screenshot%2525202015-09-04%252520001.png)

windows:
```
AVX2    encode  2252.10 MB/sec
AVX2    decode  3267.33 MB/sec
plain   encode  617.23 MB/sec
plain   decode  672.57 MB/sec
SSSE3   encode  2010.86 MB/sec
SSSE3   decode  2603.15 MB/sec
```

linux (vb):
```
plain	encode	1626.93 MB/sec
plain	decode	1469.71 MB/sec
SSSE3	encode	2203.48 MB/sec
SSSE3	decode	2683.54 MB/sec
```



