### PR TITLE
Improve SSSE3 and AVX2 encoding speed

### DIFF
--- a/lib/codec_ssse3.c
+++ b/lib/codec_ssse3.c
@@ -61,30 +61,29 @@ enc_reshuffle (__m128i in)
 static inline __m128i
 enc_translate (const __m128i in)
 {
+	// LUT contains Absolute offset for all ranges:
+	const __m128i lut = _mm_setr_epi8(65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0);
+
 	// Translate values 0..63 to the Base64 alphabet. There are five sets:
-	// #  From      To         Abs  Delta  Characters
-	// 0  [0..25]   [65..90]   +65  +65    ABCDEFGHIJKLMNOPQRSTUVWXYZ
-	// 1  [26..51]  [97..122]  +71   +6    abcdefghijklmnopqrstuvwxyz
-	// 2  [52..61]  [48..57]    -4  -75    0123456789
-	// 3  [62]      [43]       -19  -15    +
-	// 4  [63]      [47]       -16   +3    /
+	// #  From      To         Abs    Index  Characters
+	// 0  [0..25]   [65..90]   +65        0  ABCDEFGHIJKLMNOPQRSTUVWXYZ
+	// 1  [26..51]  [97..122]  +71        1  abcdefghijklmnopqrstuvwxyz
+	// 2  [52..61]  [48..57]    -4  [2..11]  0123456789
+	// 3  [62]      [43]       -19       12  +
+	// 4  [63]      [47]       -16       13  /
 
-	// Create cumulative masks for characters in sets [1,2,3,4], [2,3,4],
-	// [3,4], and [4]:
-	const __m128i mask1 = CMPGT(in, 25);
-	const __m128i mask2 = CMPGT(in, 51);
-	const __m128i mask3 = CMPGT(in, 61);
-	const __m128i mask4 = CMPEQ(in, 63);
+	// Create LUT indices from input:
+	// the index for range #0 is right, others are 1 less than expected:
+	__m128i indices = _mm_subs_epu8(in, _mm_set1_epi8(51));
 
-	// All characters are at least in cumulative set 0, so add 'A':
-	__m128i out = _mm_add_epi8(in, _mm_set1_epi8(65));
+	// mask is 0xFF (-1) for range #[1..4] and 0x00 for range #0:
+	__m128i mask = CMPGT(in, 25);
 
-	// For inputs which are also in any of the other cumulative sets,
-	// add delta values against the previous set(s) to correct the shift:
-	out = _mm_add_epi8(out, REPLACE(mask1,  6));
-	out = _mm_sub_epi8(out, REPLACE(mask2, 75));
-	out = _mm_sub_epi8(out, REPLACE(mask3, 15));
-	out = _mm_add_epi8(out, REPLACE(mask4,  3));
+	// substract -1, so add 1 to indices for range #[1..4], All indices are now correct:
+	indices = _mm_sub_epi8(indices, mask);
+
+	// Add offsets to input values:
+	__m128i out = _mm_add_epi8(in, _mm_shuffle_epi8(lut, indices));
 
 	return out;
 }


### PR DESCRIPTION
The `enc_translate` function now uses less instructions and only 3 constants.
Speed-up on `Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz` using `Apple LLVM version 8.0.0 (clang-800.0.38)`
AVX2: +45% compared to previous version
SSSE3: +54% compared to previous version

The AVX2 flavor uses:
- 3 add/sub instructions
- 1 comparison instruction
- 1 shuffle instruction

The SSSE3 flavor uses:
- 3 add/sub instructions
- 1 comparison instruction
- 1 shuffle instruction
- 3 copy instructions

Full results before & after modifications follows.
Before:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 10 * 1
AVX2	encode	5772.70 MB/sec
AVX2	decode	6373.58 MB/sec
plain	encode	1344.26 MB/sec
plain	decode	1446.26 MB/sec
SSSE3	encode	3562.93 MB/sec
SSSE3	decode	3315.56 MB/sec
Testing with buffer size 1 MB, fastest of 10 * 10
AVX2	encode	5824.07 MB/sec
AVX2	decode	6292.53 MB/sec
plain	encode	1491.26 MB/sec
plain	decode	1430.49 MB/sec
SSSE3	encode	3594.22 MB/sec
SSSE3	decode	3485.10 MB/sec
Testing with buffer size 100 KB, fastest of 10 * 100
AVX2	encode	5860.74 MB/sec
AVX2	decode	6439.77 MB/sec
plain	encode	1470.44 MB/sec
plain	decode	1478.82 MB/sec
SSSE3	encode	3598.01 MB/sec
SSSE3	decode	3531.33 MB/sec
Testing with buffer size 10 KB, fastest of 100 * 100
AVX2	encode	5796.35 MB/sec
AVX2	decode	6395.72 MB/sec
plain	encode	1498.13 MB/sec
plain	decode	1476.94 MB/sec
SSSE3	encode	3592.39 MB/sec
SSSE3	decode	3580.89 MB/sec
Testing with buffer size 1 KB, fastest of 100 * 1000
AVX2	encode	4768.07 MB/sec
AVX2	decode	5258.08 MB/sec
plain	encode	1417.29 MB/sec
plain	decode	1440.80 MB/sec
SSSE3	encode	3369.49 MB/sec
SSSE3	decode	3397.11 MB/sec
```

After:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 10 * 1
AVX2	encode	7736.49 MB/sec
AVX2	decode	6393.49 MB/sec
plain	encode	1425.47 MB/sec
plain	decode	1510.67 MB/sec
SSSE3	encode	5576.68 MB/sec
SSSE3	decode	3568.17 MB/sec
Testing with buffer size 1 MB, fastest of 10 * 10
AVX2	encode	8728.56 MB/sec
AVX2	decode	4699.43 MB/sec
plain	encode	1408.76 MB/sec
plain	decode	1556.61 MB/sec
SSSE3	encode	5679.42 MB/sec
SSSE3	decode	3596.99 MB/sec
Testing with buffer size 100 KB, fastest of 10 * 100
AVX2	encode	8752.18 MB/sec
AVX2	decode	5936.24 MB/sec
plain	encode	1500.53 MB/sec
plain	decode	1560.69 MB/sec
SSSE3	encode	5529.50 MB/sec
SSSE3	decode	3492.68 MB/sec
Testing with buffer size 10 KB, fastest of 100 * 100
AVX2	encode	8889.15 MB/sec
AVX2	decode	6421.75 MB/sec
plain	encode	1501.56 MB/sec
plain	decode	1515.71 MB/sec
SSSE3	encode	5513.91 MB/sec
SSSE3	decode	3481.16 MB/sec
Testing with buffer size 1 KB, fastest of 100 * 1000
AVX2	encode	6395.93 MB/sec
AVX2	decode	5184.36 MB/sec
plain	encode	1377.24 MB/sec
plain	decode	1519.36 MB/sec
SSSE3	encode	5048.06 MB/sec
SSSE3	decode	3397.37 MB/sec
```