### PR TITLE
Add SSE4.2 code paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ compiler:
   - gcc
 
 script:
-  - SSSE3_CFLAGS=-mssse3 make -C test
+  - SSSE3_CFLAGS=-mssse3 SSE42_CFLAGS=-msse4.2 make -C test

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ OBJS = \
   lib/codec_neon32.o \
   lib/codec_neon64.o \
   lib/codec_plain.o \
-  lib/codec_ssse3.o
+  lib/codec_ssse3.o \
+  lib/codec_sse42.o
 
 HAVE_AVX2   = 0
 HAVE_NEON32 = 0
 HAVE_NEON64 = 0
 HAVE_SSSE3  = 0
+HAVE_SSE42  = 0
 
 # The user should supply compiler flags for the codecs they want to build.
 # Check which codecs we're going to include:
@@ -30,6 +32,9 @@ ifdef NEON64_CFLAGS
 endif
 ifdef SSSE3_CFLAGS
   HAVE_SSSE3 = 1
+endif
+ifdef SSE42_CFLAGS
+  HAVE_SSE42 = 1
 endif
 ifdef OPENMP
   CFLAGS += -fopenmp
@@ -52,6 +57,7 @@ lib/config.h:
 	@echo "#define HAVE_NEON32 $(HAVE_NEON32)" >> $@
 	@echo "#define HAVE_NEON64 $(HAVE_NEON64)" >> $@
 	@echo "#define HAVE_SSSE3  $(HAVE_SSSE3)"  >> $@
+	@echo "#define HAVE_SSE42  $(HAVE_SSE42)"  >> $@
 
 lib/codec_choose.o: lib/config.h
 
@@ -59,6 +65,7 @@ lib/codec_avx2.o:   CFLAGS += $(AVX2_CFLAGS)
 lib/codec_neon32.o: CFLAGS += $(NEON32_CFLAGS)
 lib/codec_neon64.o: CFLAGS += $(NEON64_CFLAGS)
 lib/codec_ssse3.o:  CFLAGS += $(SSSE3_CFLAGS)
+lib/codec_sse42.o:  CFLAGS += $(SSE42_CFLAGS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<

--- a/include/libbase64.h
+++ b/include/libbase64.h
@@ -15,6 +15,7 @@ extern "C" {
 #define BASE64_FORCE_NEON64	(1 << 2)
 #define BASE64_FORCE_PLAIN	(1 << 3)
 #define BASE64_FORCE_SSSE3	(1 << 4)
+#define BASE64_FORCE_SSE42	(1 << 5)
 
 struct base64_state {
 	int eof;

--- a/lib/codec_sse42.c
+++ b/lib/codec_sse42.c
@@ -1,0 +1,49 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "../include/libbase64.h"
+#include "codecs.h"
+
+#ifdef __SSE4_2__
+#include <nmmintrin.h>
+
+#define CMPGT(s,n)	_mm_cmpgt_epi8((s), _mm_set1_epi8(n))
+
+static inline __m128i
+dec_reshuffle (__m128i in)
+{
+	// Mask in a single byte per shift:
+	const __m128i maskB2 = _mm_set1_epi32(0x003F0000);
+	const __m128i maskB1 = _mm_set1_epi32(0x00003F00);
+
+	// Pack bytes together:
+	__m128i out = _mm_srli_epi32(in, 16);
+
+	out = _mm_or_si128(out, _mm_srli_epi32(_mm_and_si128(in, maskB2), 2));
+
+	out = _mm_or_si128(out, _mm_slli_epi32(_mm_and_si128(in, maskB1), 12));
+
+	out = _mm_or_si128(out, _mm_slli_epi32(in, 26));
+
+	// Reshuffle and repack into 12-byte output format:
+	return _mm_shuffle_epi8(out, _mm_setr_epi8(
+		 3,  2,  1,
+		 7,  6,  5,
+		11, 10,  9,
+		15, 14, 13,
+		-1, -1, -1, -1));
+}
+
+#endif	// __SSE42__
+
+BASE64_DEC_FUNCTION(sse42)
+{
+#ifdef __SSE4_2__
+	#include "dec/head.c"
+	#include "dec/sse42.c"
+	#include "dec/tail.c"
+#else
+	BASE64_DEC_STUB
+#endif
+}

--- a/lib/dec/sse42.c
+++ b/lib/dec/sse42.c
@@ -1,0 +1,85 @@
+// If we have SSE4.2 support, pick off 16 bytes at a time for as long as we can,
+// but make sure that we quit before seeing any == markers at the end of the
+// string. Also, because we write four zeroes at the end of the output, ensure
+// that there are at least 6 valid bytes of input data remaining to close the
+// gap. 16 + 2 + 6 = 24 bytes:
+while (srclen >= 24)
+{
+	// Load string:
+	__m128i str = _mm_loadu_si128((__m128i *)c);
+
+	// The input consists of six character sets in the Base64 alphabet,
+	// which we need to map back to the 6-bit values they represent.
+	// There are three ranges, two singles, and then there's the rest.
+	//
+	//  #  From       To        Add    Index  Characters
+	//  1  [43]       [62]      +19        0  +
+	//  2  [47]       [63]      +16        1  /
+	//  3  [48..57]   [52..61]   +4  [2..11]  0..9
+	//  4  [65..90]   [0..25]   -65       15  A..Z
+	//  5  [97..122]  [26..51]  -71       14  a..z
+	// (6) Everything else => invalid input
+
+	// LUT:
+	const __m128i lut = _mm_setr_epi8(19,16,4,4,4,4,4,4,4,4,4,4,0,0,-71,-65);
+
+	// Ranges to be checked (all should be valid, repeat the first one):
+	const __m128i range = _mm_setr_epi8(
+		'+','+',
+		'+','+',
+		'+','+',
+		'+','+',
+		'/','/',
+		'0','9',
+		'A','Z',
+		'a','z');
+
+	// Check for invalid input:
+	// pseudo-code for the _mm_cmpistrc call:
+	// out_of_range = 0
+	// for each byte of str
+	//   out_of_range |= !(byte in one of the ranges)
+	// return out_of_range
+	if (_mm_cmpistrc(range, str, _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES | _SIDD_NEGATIVE_POLARITY)) {
+		break;
+	}
+
+	// Compute indices for table look up:
+	// First indices for ranges #[1..3]. Others are invalid.
+	__m128i indices = _mm_subs_epu8(str, _mm_set1_epi8(46));
+
+	// Compute mask for ranges #4 and #5:
+	__m128i maskUL = CMPGT(str, 64);
+
+	// Compute mask for range #5:
+	__m128i maskL  = CMPGT(str, 96);
+
+	// Clear invalid values in indices:
+	indices = _mm_andnot_si128(maskUL, indices);
+
+	// Compute index for range #4: (abs(-1) << 4) + -1 = 15. Index for range #5 is off by one:
+	maskUL = _mm_add_epi8(_mm_slli_epi16(_mm_abs_epi8(maskUL), 4), maskUL);
+
+	// Set all indices. Index for range #5 is still off by one:
+	indices = _mm_add_epi8(indices, maskUL);
+
+	// add -1, so substract 1 to indices for range #5, All indices are now correct:
+	indices = _mm_add_epi8(indices, maskL);
+
+	// Lookup deltas:
+	__m128i delta = _mm_shuffle_epi8(lut, indices);
+
+	// Now simply add the delta values to the input:
+	str = _mm_add_epi8(str, delta);
+
+	// Reshuffle the input to packed 12-byte output format:
+	str = dec_reshuffle(str);
+
+	// Store back:
+	_mm_storeu_si128((__m128i *)o, str);
+
+	c += 16;
+	o += 12;
+	outl += 12;
+	srclen -= 16;
+}

--- a/lib/lib.c
+++ b/lib/lib.c
@@ -49,7 +49,7 @@ void
 base64_stream_encode_init (struct base64_state *state, int flags)
 {
 	// If any of the codec flags are set, redo choice:
-	if (codec.enc == NULL || flags & 0x1F) {
+	if (codec.enc == NULL || flags & 0x3F) {
 		codec_choose(&codec, flags);
 	}
 	state->eof = 0;
@@ -99,7 +99,7 @@ void
 base64_stream_decode_init (struct base64_state *state, int flags)
 {
 	// If any of the codec flags are set, redo choice:
-	if (codec.dec == NULL || flags & 0x1F) {
+	if (codec.dec == NULL || flags & 0x3F) {
 		codec_choose(&codec, flags);
 	}
 	state->eof = 0;

--- a/test/codec_supported.c
+++ b/test/codec_supported.c
@@ -8,6 +8,7 @@ static char *_codecs[] =
 , "NEON64"
 , "plain"
 , "SSSE3"
+, "SSE42"
 , NULL
 } ;
 


### PR DESCRIPTION
SSE4.2 has been added for decoding.

Speed-up on `Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz` using `Apple LLVM version 8.0.0 (clang-800.0.38)`

SSE4.2 decoding: +29% compared to SSSE3 in ab7a48bcbc8066e2e200836dd9f40a2b44dda35b

Full results (this builds on top of #17):
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
AVX2	encode	7876.40 MB/sec
AVX2    decode  7047.91 MB/sec
plain   encode  1499.65 MB/sec
plain   decode  1557.21 MB/sec
SSSE3	encode	5612.09 MB/sec
SSSE3	decode	3883.52 MB/sec
SSE42	encode	5600.26 MB/sec
SSE42	decode	5089.87 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
AVX2    encode  8970.38 MB/sec
AVX2    decode  7093.07 MB/sec
plain   encode  1501.03 MB/sec
plain   decode  1562.29 MB/sec
SSSE3	encode	5681.83 MB/sec
SSSE3	decode	3902.85 MB/sec
SSE42	encode	5681.28 MB/sec
SSE42	decode	5108.25 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
AVX2    encode  9010.17 MB/sec
AVX2	decode	7036.27 MB/sec
plain   encode  1500.42 MB/sec
plain   decode  1561.01 MB/sec
SSSE3	encode	5698.98 MB/sec
SSSE3	decode	3901.21 MB/sec
SSE42	encode	5698.52 MB/sec
SSE42	decode	5103.18 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
AVX2    encode  8928.00 MB/sec
AVX2	decode	6923.62 MB/sec
plain   encode  1504.46 MB/sec
plain   decode  1558.74 MB/sec
SSSE3   encode  5672.21 MB/sec
SSSE3	decode	3912.51 MB/sec
SSE42	encode	5674.36 MB/sec
SSE42	decode	5078.06 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
AVX2    encode  6726.56 MB/sec
AVX2	decode	5761.74 MB/sec
plain	encode	1420.93 MB/sec
plain   decode  1519.19 MB/sec
SSSE3   encode  5090.29 MB/sec
SSSE3	decode	3604.62 MB/sec
SSE42	encode	5023.86 MB/sec
SSE42	decode	4496.14 MB/sec
```