### PR TITLE
Add build support for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ bin/base64: bin/base64.o lib/libbase64.o
 	$(CC) $(CFLAGS) -o $@ $^
 
 lib/libbase64.o: $(OBJS)
-	$(LD) --relocatable -o $@ $^
+	$(LD) -r -o $@ $^
 	$(OBJCOPY) --keep-global-symbols=lib/exports.txt $@
 
 lib/config.h:

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,14 @@ ifdef OPENMP
   CFLAGS += -fopenmp
 endif
 
+TARGET := $(shell $(CC) -dumpmachine)
+ifneq (, $(findstring darwin, $(TARGET)))
+  BENCH_LDFLAGS=
+else
+  # default to linux, -lrt needed
+  BENCH_LDFLAGS=-lrt
+endif
+
 .PHONY: clean test
 
 test: clean test_base64 benchmark
@@ -13,7 +21,7 @@ test_base64: test_base64.c codec_supported.o ../lib/libbase64.o
 	$(CC) $(CFLAGS) -o $@ $^
 
 benchmark: benchmark.c codec_supported.o ../lib/libbase64.o
-	$(CC) $(CFLAGS) -o $@ $^ -lrt
+	$(CC) $(CFLAGS) -o $@ $^ $(BENCH_LDFLAGS)
 
 ../%:
 	make -C .. $*


### PR DESCRIPTION
Modified Makefile to use -r instead of --relocatable so that it can be
used with MacOS linker as well.
Modified test/Makefile not to link with librt under MacOS.
Modified test/benchmark.c to use MACH time functions under MacOS.