### PR TITLE
Improve AVX2 encoding speed

### DIFF
--- a/lib/codec_avx2.c
+++ b/lib/codec_avx2.c
@@ -50,14 +50,8 @@ enc_reshuffle (__m256i in)
 		-1, 3,  4,  5,
 		-1, 0,  1,  2));
 
-	// cd      = [00000000|00000000|0000cccc|ccdddddd]
-	const __m256i cd = _mm256_and_si256(in, _mm256_set1_epi32(0x00000FFF));
-
-	// ab      = [0000aaaa|aabbbbbb|00000000|00000000]
-	const __m256i ab = _mm256_and_si256(_mm256_slli_epi32(in, 4), _mm256_set1_epi32(0x0FFF0000));
-
-	// merged  = [0000aaaa|aabbbbbb|0000cccc|ccdddddd]
-	const __m256i merged = _mm256_or_si256(ab, cd);
+	// merged  = [0000aaaa|aabbbbbb|bbbbcccc|ccdddddd]
+	const __m256i merged = _mm256_blend_epi16(_mm256_slli_epi32(in, 4), in, 0x55);
 
 	// bd      = [00000000|00bbbbbb|00000000|00dddddd]
 	const __m256i bd = _mm256_and_si256(merged, _mm256_set1_epi32(0x003F003F));


### PR DESCRIPTION
Modified AVX2 `enc_reshuffle` function to use a blend instruction instead of 3 logical (2 * and, 1 * or) instructions. Also removes the need for 2 constants.

Speed-up on `Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz` using `Apple LLVM version 8.0.0 (clang-800.0.38)`

AVX2: +8% compared to previous version

Full results before & after modifications follows.
Before:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
AVX2    encode  7876.40 MB/sec
AVX2    decode  7047.91 MB/sec
plain   encode  1499.65 MB/sec
plain   decode  1557.21 MB/sec
SSSE3   encode  5612.09 MB/sec
SSSE3   decode  3883.52 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
AVX2    encode  8970.38 MB/sec
AVX2    decode  7093.07 MB/sec
plain   encode  1501.03 MB/sec
plain   decode  1562.29 MB/sec
SSSE3   encode  5681.83 MB/sec
SSSE3   decode  3902.85 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
AVX2    encode  9010.17 MB/sec
AVX2    decode  7036.27 MB/sec
plain   encode  1500.42 MB/sec
plain   decode  1561.01 MB/sec
SSSE3   encode  5698.98 MB/sec
SSSE3   decode  3901.21 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
AVX2    encode  8928.00 MB/sec
AVX2    decode  6923.62 MB/sec
plain   encode  1504.46 MB/sec
plain   decode  1558.74 MB/sec
SSSE3   encode  5672.21 MB/sec
SSSE3   decode  3912.51 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
AVX2    encode  6726.56 MB/sec
AVX2    decode  5761.74 MB/sec
plain   encode  1420.93 MB/sec
plain   decode  1519.19 MB/sec
SSSE3   encode  5090.29 MB/sec
SSSE3   decode  3604.62 MB/sec
```
After:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
AVX2	encode	8104.70 MB/sec
AVX2    decode  7047.91 MB/sec
plain   encode  1499.65 MB/sec
plain   decode  1557.21 MB/sec
SSSE3	encode	5612.09 MB/sec
SSSE3	decode	3883.52 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
AVX2	encode	9691.90 MB/sec
AVX2    decode  7093.07 MB/sec
plain   encode  1501.03 MB/sec
plain   decode  1562.29 MB/sec
SSSE3	encode	5681.83 MB/sec
SSSE3	decode	3902.85 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
AVX2	encode	9778.19 MB/sec
AVX2	decode	7072.35 MB/sec
plain   encode  1500.42 MB/sec
plain   decode  1561.01 MB/sec
SSSE3	encode	5698.98 MB/sec
SSSE3	decode	3901.21 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
AVX2	encode	9714.04 MB/sec
AVX2	decode	7018.01 MB/sec
plain   encode  1504.46 MB/sec
plain   decode  1558.74 MB/sec
SSSE3   encode  5672.21 MB/sec
SSSE3	decode	3918.76 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
AVX2	encode	7165.17 MB/sec
AVX2	decode	5761.74 MB/sec
plain	encode	1420.93 MB/sec
plain   decode  1519.19 MB/sec
SSSE3   encode  5090.29 MB/sec
SSSE3	decode	3604.62 MB/sec
```