### PR TITLE
Improve NEON64 decoding speed

### DIFF
--- a/lib/arch/neon64/codec.c
+++ b/lib/arch/neon64/codec.c
@@ -15,10 +15,8 @@
 #if (defined(__aarch64__) && defined(__ARM_NEON__))
 
 #define CMPGT(s,n)	vcgtq_u8((s), vdupq_n_u8(n))
-#define CMPEQ(s,n)	vceqq_u8((s), vdupq_n_u8(n))
-#define REPLACE(s,n)	vandq_u8((s), vdupq_n_u8(n))
-#define RANGE(s,a,b)	vandq_u8(vcgeq_u8((s), vdupq_n_u8(a)), vcleq_u8((s), vdupq_n_u8(b)))
 
+// Encoding
 // With this transposed encoding table, we can use
 // a 64-byte lookup to do the encoding.
 // Read the table top to bottom, left to right.
@@ -41,6 +39,53 @@ static const char *base64_table_enc_transposed =
 	"Oeu+"
 	"Pfv/"
 };
+
+// Decoding
+// The input consists of five valid character sets in the Base64 alphabet,
+// which we need to map back to the 6-bit values they represent.
+// There are three ranges, two singles, and then there's the rest.
+//
+//   #  From       To        LUT  Characters
+//   1  [0..42]    [255]      #1  invalid input
+//   2  [43]       [62]       #1  +
+//   3  [44..46]   [255]      #1  invalid input
+//   4  [47]       [63]       #1  /
+//   5  [48..57]   [52..61]   #1  0..9
+//   6  [58..63]   [255]      #1  invalid input
+//   7  [64]       [255]      #2  invalid input
+//   8  [65..90]   [0..25]    #2  A..Z
+//   9  [91..96]   [255]      #2 invalid input
+//  10  [97..122]  [26..51]   #2  a..z
+//  11  [123..126] [255]      #2 invalid input
+// (12) Everything else => invalid input
+
+// First LUT will use VTBL instruction (out of range indices are set to 0 in destination).
+static const uint8_t base64_dec_lut1[] =
+{
+	255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U,
+	255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U,
+	255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U, 255U,  62U, 255U, 255U, 255U,  63U,
+	 52U,  53U,  54U,  55U,  56U,  57U,  58U,  59U,  60U,  61U, 255U, 255U, 255U, 255U, 255U, 255U
+};
+// Second LUT will use VTBX instruction (out of range indices will be unchanged in destination).
+// Input [64..126] will be mapped to index [1..63] in this LUT. Index 0 means that value comes from LUT #1.
+static const uint8_t base64_dec_lut2[] =
+{
+	  0U, 255U,   0U,   1U,   2U,   3U,   4U,   5U,   6U,   7U,   8U,   9U,  10U,  11U,  12U,  13U,
+	 14U,  15U,  16U,  17U,  18U,  19U,  20U,  21U,  22U,  23U,  24U,  25U, 255U, 255U, 255U, 255U,
+	255U, 255U,  26U,  27U,  28U,  29U,  30U,  31U,  32U,  33U,  34U,  35U,  36U,  37U,  38U,  39U,
+	 40U,  41U,  42U,  43U,  44U,  45U,  46U,  47U,  48U,  49U,  50U,  51U, 255U, 255U, 255U, 255U
+};
+
+// All input values in range for the first look-up will be 0U in the second look-up result.
+// All input values out of range for the first look-up will be 0U in the first look-up result.
+// Thus, the two results can be ORed without conflicts.
+// Invalid characters that are in the valid range for either look-up will be set to 255U in the combined result.
+// Other invalid characters will just be passed through with the second look-up result (using VTBX instruction).
+// Since the second LUT is 64 bytes, those passed through values are guaranteed to have a value greater than 63U.
+// Therefore, valid characters will be mapped to the valid [0..63] range and all invalid characters will be mapped
+// to values greater than 63.
+
 #endif
 
 // Stride size is so large on these NEON 64-bit functions
@@ -64,9 +109,11 @@ BASE64_ENC_FUNCTION(neon64)
 BASE64_DEC_FUNCTION(neon64)
 {
 #if (defined(__aarch64__) && defined(__ARM_NEON__))
+	uint8x16x4_t tbl_dec1 = vld1q_u8_x4(base64_dec_lut1);
+	uint8x16x4_t tbl_dec2 = vld1q_u8_x4(base64_dec_lut2);
 
 	#include "../generic/dec_head.c"
-	#include "../neon32/dec_loop.c"
+	#include "dec_loop.c"
 	#include "../generic/64/dec_loop.c"
 	#include "../generic/dec_tail.c"
 #else

--- a/lib/arch/neon64/dec_loop.c
+++ b/lib/arch/neon64/dec_loop.c
@@ -1,0 +1,60 @@
+// If we have NEON support, pick off 64 bytes at a time for as long as we can.
+// Unlike the SSE codecs, we don't write trailing zero bytes to output, so we
+// don't need to check if we have enough remaining input to cover them:
+while (srclen >= 64)
+{
+	const uint8x16_t offset = vdupq_n_u8(63U);
+	uint8x16x4_t dec1, dec2;
+	uint8x16x3_t dec;
+
+	// Load 64 bytes and deinterleave:
+	uint8x16x4_t str = vld4q_u8((uint8_t *)c);
+
+	// Get indices for 2nd LUT
+	dec2.val[0] = vqsubq_u8(str.val[0], offset);
+	dec2.val[1] = vqsubq_u8(str.val[1], offset);
+	dec2.val[2] = vqsubq_u8(str.val[2], offset);
+	dec2.val[3] = vqsubq_u8(str.val[3], offset);
+
+	// Get values from 1st LUT
+	dec1.val[0] = vqtbl4q_u8(tbl_dec1, str.val[0]);
+	dec1.val[1] = vqtbl4q_u8(tbl_dec1, str.val[1]);
+	dec1.val[2] = vqtbl4q_u8(tbl_dec1, str.val[2]);
+	dec1.val[3] = vqtbl4q_u8(tbl_dec1, str.val[3]);
+
+	// Get values from 2nd LUT
+	dec2.val[0] = vqtbx4q_u8(dec2.val[0], tbl_dec2, dec2.val[0]);
+	dec2.val[1] = vqtbx4q_u8(dec2.val[1], tbl_dec2, dec2.val[1]);
+	dec2.val[2] = vqtbx4q_u8(dec2.val[2], tbl_dec2, dec2.val[2]);
+	dec2.val[3] = vqtbx4q_u8(dec2.val[3], tbl_dec2, dec2.val[3]);
+
+	// Get final values
+	str.val[0] = vorrq_u8(dec1.val[0], dec2.val[0]);
+	str.val[1] = vorrq_u8(dec1.val[1], dec2.val[1]);
+	str.val[2] = vorrq_u8(dec1.val[2], dec2.val[2]);
+	str.val[3] = vorrq_u8(dec1.val[3], dec2.val[3]);
+
+	// Check for invalid input, any value larger than 63:
+	uint8x16_t classified = CMPGT(str.val[0], 63);
+	classified = vorrq_u8(classified, CMPGT(str.val[1], 63));
+	classified = vorrq_u8(classified, CMPGT(str.val[2], 63));
+	classified = vorrq_u8(classified, CMPGT(str.val[3], 63));
+
+	// check that all bits are zero:
+	if (vmaxvq_u8(classified) != 0U) {
+		break;
+	}
+
+	// Compress four bytes into three:
+	dec.val[0] = vshlq_n_u8(str.val[0], 2) | vshrq_n_u8(str.val[1], 4);
+	dec.val[1] = vshlq_n_u8(str.val[1], 4) | vshrq_n_u8(str.val[2], 2);
+	dec.val[2] = vshlq_n_u8(str.val[2], 6) | str.val[3];
+
+	// Interleave and store decoded result:
+	vst3q_u8((uint8_t *)o, dec);
+
+	c += 64;
+	o += 48;
+	outl += 48;
+	srclen -= 64;
+}


### PR DESCRIPTION
The decoding loop now uses a composite 128 bytes LUT (two 64 bytes LUT)

Speed-up on `iPhone SE` using `Apple LLVM version 8.0.0 (clang-800.0.38)`

NEON64: +130% compared to previous version

Full results before & after modifications follows.
Before:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
NEON64	encode	4098.43 MB/sec
NEON64	decode	1726.01 MB/sec
plain	encode	1060.69 MB/sec
plain	decode	1236.70 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
NEON64	encode	6550.93 MB/sec
NEON64	decode	1744.40 MB/sec
plain	encode	1062.92 MB/sec
plain	decode	1235.20 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
NEON64	encode	6537.48 MB/sec
NEON64	decode	1733.39 MB/sec
plain	encode	1063.61 MB/sec
plain	decode	1233.14 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
NEON64	encode	6499.58 MB/sec
NEON64	decode	1751.95 MB/sec
plain	encode	1080.12 MB/sec
plain	decode	1237.07 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
NEON64	encode	5840.41 MB/sec
NEON64	decode	1700.96 MB/sec
plain	encode	1059.08 MB/sec
plain	decode	1206.38 MB/sec
```

After:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
NEON64	encode	4102.50 MB/sec
NEON64	decode	3984.66 MB/sec
plain	encode	1061.91 MB/sec
plain	decode	1234.36 MB/sec
Testing with buffer size 1 MB, fastest of 10 * 100
NEON64	encode	6508.42 MB/sec
NEON64	decode	3984.97 MB/sec
plain	encode	1060.76 MB/sec
plain	decode	1231.69 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
NEON64	encode	6534.92 MB/sec
NEON64	decode	3989.63 MB/sec
plain	encode	1062.90 MB/sec
plain	decode	1233.14 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
NEON64	encode	6476.27 MB/sec
NEON64	decode	3968.43 MB/sec
plain	encode	1082.06 MB/sec
plain	decode	1238.31 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
NEON64	encode	5840.41 MB/sec
NEON64	decode	3923.26 MB/sec
plain	encode	1065.29 MB/sec
plain	decode	1220.13 MB/sec
```