### PR TITLE
Improve NEON32 decoding speed

### DIFF
--- a/lib/arch/neon32/dec_loop.c
+++ b/lib/arch/neon32/dec_loop.c
@@ -31,10 +31,10 @@ while (srclen >= 64)
 		set5.val[i] = RANGE(str.val[i], 'a', 'z');
 
 		delta.val[i] = REPLACE(set1.val[i], 19);
-		delta.val[i] = vorrq_u8(delta.val[i], REPLACE(set2.val[i],  16));
-		delta.val[i] = vorrq_u8(delta.val[i], REPLACE(set3.val[i],   4));
-		delta.val[i] = vorrq_u8(delta.val[i], REPLACE(set4.val[i], -65));
-		delta.val[i] = vorrq_u8(delta.val[i], REPLACE(set5.val[i], -71));
+		delta.val[i] = vbslq_u8(set2.val[i], vdupq_n_u8( 16), delta.val[i]);
+		delta.val[i] = vbslq_u8(set3.val[i], vdupq_n_u8(  4), delta.val[i]);
+		delta.val[i] = vbslq_u8(set4.val[i], vdupq_n_u8(-65), delta.val[i]);
+		delta.val[i] = vbslq_u8(set5.val[i], vdupq_n_u8(-71), delta.val[i]);
 	}
 
 	// Check for invalid input: if any of the delta values are zero,


### PR DESCRIPTION
The decoding loop now uses a single `vbslq_u8` (select instruction)
instead of one `vorrq_u8` and one `vandq_u8` instructions for each
delta update.

Speed-up on `iPhone SE` using `Apple LLVM version 8.0.0 (clang-800.0.38)`

NEON32: +7% compared to previous version

Full results before & after modifications follows. I also added timings with innermost loop unrolled (+40%). Seems unrolling was reverted to standard looping after some benchmark with `Raspberry Pi 2B` and `Clang`. The combination I'm using definitely prefers the unrolled version (was also the case with previous version which falls in between `After` and `After unrolled`). 

Before:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
NEON32	encode	2940.06 MB/sec
NEON32	decode	1427.43 MB/sec
plain	encode	1051.86 MB/sec
plain	decode	721.74 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
NEON32	encode	2945.80 MB/sec
NEON32	decode	1428.71 MB/sec
plain	encode	1055.03 MB/sec
plain	decode	722.79 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
NEON32	encode	2941.49 MB/sec
NEON32	decode	1428.19 MB/sec
plain	encode	1054.89 MB/sec
plain	decode	721.72 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
NEON32	encode	2927.49 MB/sec
NEON32	decode	1418.65 MB/sec
plain	encode	1053.13 MB/sec
plain	decode	725.89 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
NEON32	encode	2685.02 MB/sec
NEON32	decode	1383.32 MB/sec
plain	encode	1016.33 MB/sec
plain	decode	712.32 MB/sec
```
After:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
NEON32	encode	2941.10 MB/sec
NEON32	decode	1521.40 MB/sec
plain	encode	1053.55 MB/sec
plain	decode	721.85 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
NEON32	encode	2944.39 MB/sec
NEON32	decode	1523.88 MB/sec
plain	encode	1055.86 MB/sec
plain	decode	722.79 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
NEON32	encode	2941.93 MB/sec
NEON32	decode	1524.02 MB/sec
plain	encode	1056.44 MB/sec
plain	decode	722.70 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
NEON32	encode	2927.49 MB/sec
NEON32	decode	1523.70 MB/sec
plain	encode	1053.70 MB/sec
plain	decode	726.92 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
NEON32	encode	2685.02 MB/sec
NEON32	decode	1491.22 MB/sec
plain	encode	1021.82 MB/sec
plain	decode	710.46 MB/sec
```
With innermost loop unrolled:
```
Filling buffer with 10.0 MB of random data...
Testing with buffer size 10 MB, fastest of 100 * 1
NEON32	encode	2940.89 MB/sec
NEON32	decode	2128.38 MB/sec
plain	encode	1054.95 MB/sec
plain	decode	721.83 MB/sec
Testing with buffer size 1 MB, fastest of 100 * 10
NEON32	encode	2944.71 MB/sec
NEON32	decode	2129.87 MB/sec
plain	encode	1055.33 MB/sec
plain	decode	722.82 MB/sec
Testing with buffer size 100 KB, fastest of 100 * 100
NEON32	encode	2940.97 MB/sec
NEON32	decode	2130.41 MB/sec
plain	encode	1055.32 MB/sec
plain	decode	722.67 MB/sec
Testing with buffer size 10 KB, fastest of 1000 * 100
NEON32	encode	2927.49 MB/sec
NEON32	decode	2115.30 MB/sec
plain	encode	1053.18 MB/sec
plain	decode	725.66 MB/sec
Testing with buffer size 1 KB, fastest of 1000 * 1000
NEON32	encode	2665.17 MB/sec
NEON32	decode	2041.24 MB/sec
plain	encode	1017.08 MB/sec
plain	decode	696.24 MB/sec
```