### PR TITLE
Fix build under Xcode

### DIFF
--- a/test/codec_supported.h
+++ b/test/codec_supported.h
@@ -1,3 +1,3 @@
-char **codecs;
+extern char **codecs;
 
 int codec_supported (int flags);


### PR DESCRIPTION
When building from Xcode, the link stage fails with an error on
duplicated symbols.
```
duplicate symbol _codecs in:
    /Users/Matt/Library/Developer/Xcode/DerivedData/base64-agluyaxujspnxhfchqvuyxeextlu/Build/Intermediates/base64.build/Debug/test_base64.build/Objects-normal/x86_64/test_base64.o
    /Users/Matt/Library/Developer/Xcode/DerivedData/base64-agluyaxujspnxhfchqvuyxeextlu/Build/Intermediates/base64.build/Debug/test_base64.build/Objects-normal/x86_64/codec_supported.o
```
Adding extern to the symbol declaration in the header file fixes this
issue.