### PR TITLE
Do the same checks in codecs than in codec_choose

### DIFF
--- a/lib/arch/avx/codec.c
+++ b/lib/arch/avx/codec.c
@@ -5,7 +5,7 @@
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#ifdef __AVX__
+#if HAVE_AVX
 #include <immintrin.h>
 
 #include "../sse2/compare_macros.h"
@@ -14,11 +14,11 @@
 #include "../ssse3/enc_translate.c"
 #include "../ssse3/enc_reshuffle.c"
 
-#endif	// __AVX__
+#endif	// HAVE_AVX
 
 BASE64_ENC_FUNCTION(avx)
 {
-#ifdef __AVX__
+#if HAVE_AVX
 	#include "../generic/enc_head.c"
 	#include "../ssse3/enc_loop.c"
 	#include "../generic/enc_tail.c"
@@ -29,7 +29,7 @@ BASE64_ENC_FUNCTION(avx)
 
 BASE64_DEC_FUNCTION(avx)
 {
-#ifdef __AVX__
+#if HAVE_AVX
 	#include "../generic/dec_head.c"
 	#include "../ssse3/dec_loop.c"
 	#include "../generic/dec_tail.c"

--- a/lib/arch/avx2/codec.c
+++ b/lib/arch/avx2/codec.c
@@ -5,7 +5,7 @@
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#ifdef __AVX2__
+#if HAVE_AVX2
 #include <immintrin.h>
 
 #define CMPGT(s,n)	_mm256_cmpgt_epi8((s), _mm256_set1_epi8(n))
@@ -158,11 +158,11 @@ dec_reshuffle (__m256i in)
 	return _mm256_permutevar8x32_epi32(out, _mm256_setr_epi32(0, 1, 2, 4, 5, 6, -1, -1));
 }
 
-#endif	// __AVX2__
+#endif	// HAVE_AVX2
 
 BASE64_ENC_FUNCTION(avx2)
 {
-#ifdef __AVX2__
+#if HAVE_AVX2
 	#include "../generic/enc_head.c"
 	#include "enc_loop.c"
 	#include "../generic/enc_tail.c"
@@ -173,7 +173,7 @@ BASE64_ENC_FUNCTION(avx2)
 
 BASE64_DEC_FUNCTION(avx2)
 {
-#ifdef __AVX2__
+#if HAVE_AVX2
 	#include "../generic/dec_head.c"
 	#include "dec_loop.c"
 	#include "../generic/dec_tail.c"

--- a/lib/arch/neon32/codec.c
+++ b/lib/arch/neon32/codec.c
@@ -5,14 +5,13 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
-#ifdef __ARM_NEON__
-#include <arm_neon.h>
-#endif
 
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#if (defined(__arm__) && defined(__ARM_NEON__))
+#if (defined(__arm__) && defined(__ARM_NEON__) && HAVE_NEON32)
+
+#include <arm_neon.h>
 
 #define CMPGT(s,n)	vcgtq_u8((s), vdupq_n_u8(n))
 #define CMPEQ(s,n)	vceqq_u8((s), vdupq_n_u8(n))
@@ -119,7 +118,7 @@ enc_translate (uint8x16x4_t in)
 
 BASE64_ENC_FUNCTION(neon32)
 {
-#if (defined(__arm__) && defined(__ARM_NEON__))
+#if (defined(__arm__) && defined(__ARM_NEON__) && HAVE_NEON32)
 	#include "../generic/enc_head.c"
 	#include "enc_loop.c"
 	#include "../generic/32/enc_loop.c"
@@ -131,7 +130,7 @@ BASE64_ENC_FUNCTION(neon32)
 
 BASE64_DEC_FUNCTION(neon32)
 {
-#if (defined(__arm__) && defined(__ARM_NEON__))
+#if (defined(__arm__) && defined(__ARM_NEON__) && HAVE_NEON32)
 	#include "../generic/dec_head.c"
 	#include "dec_loop.c"
 	#include "../generic/32/dec_loop.c"

--- a/lib/arch/neon64/codec.c
+++ b/lib/arch/neon64/codec.c
@@ -5,14 +5,12 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
-#ifdef __ARM_NEON__
-#include <arm_neon.h>
-#endif
 
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#if (defined(__aarch64__) && defined(__ARM_NEON__))
+#if (defined(__aarch64__) && defined(__ARM_NEON__) && HAVE_NEON64)
+#include <arm_neon.h>
 
 #define CMPGT(s,n)	vcgtq_u8((s), vdupq_n_u8(n))
 
@@ -90,7 +88,7 @@ static const uint8_t base64_dec_lut2[] =
 
 BASE64_ENC_FUNCTION(neon64)
 {
-#if (defined(__aarch64__) && defined(__ARM_NEON__))
+#if (defined(__aarch64__) && defined(__ARM_NEON__) && HAVE_NEON64)
 	const uint8x16x4_t tbl_enc = load_64byte_table(base64_table_enc);
 
 	#include "../generic/enc_head.c"
@@ -104,7 +102,7 @@ BASE64_ENC_FUNCTION(neon64)
 
 BASE64_DEC_FUNCTION(neon64)
 {
-#if (defined(__aarch64__) && defined(__ARM_NEON__))
+#if (defined(__aarch64__) && defined(__ARM_NEON__) && HAVE_NEON64)
 	const uint8x16x4_t tbl_dec1 = load_64byte_table(base64_dec_lut1);
 	const uint8x16x4_t tbl_dec2 = load_64byte_table(base64_dec_lut2);
 

--- a/lib/arch/sse41/codec.c
+++ b/lib/arch/sse41/codec.c
@@ -5,7 +5,7 @@
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#ifdef __SSE4_1__
+#if HAVE_SSE41
 #include <smmintrin.h>
 
 #include "../sse2/compare_macros.h"
@@ -14,11 +14,11 @@
 #include "../ssse3/enc_translate.c"
 #include "../ssse3/enc_reshuffle.c"
 
-#endif	// __SSE4_1__
+#endif	// HAVE_SSE41
 
 BASE64_ENC_FUNCTION(sse41)
 {
-#ifdef __SSE4_1__
+#if HAVE_SSE41
 	#include "../generic/enc_head.c"
 	#include "../ssse3/enc_loop.c"
 	#include "../generic/enc_tail.c"
@@ -29,7 +29,7 @@ BASE64_ENC_FUNCTION(sse41)
 
 BASE64_DEC_FUNCTION(sse41)
 {
-#ifdef __SSE4_1__
+#if HAVE_SSE41
 	#include "../generic/dec_head.c"
 	#include "../ssse3/dec_loop.c"
 	#include "../generic/dec_tail.c"

--- a/lib/arch/sse42/codec.c
+++ b/lib/arch/sse42/codec.c
@@ -5,7 +5,7 @@
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#ifdef __SSE4_2__
+#if HAVE_SSE42
 #include <nmmintrin.h>
 
 #include "../sse2/compare_macros.h"
@@ -14,11 +14,11 @@
 #include "../ssse3/enc_translate.c"
 #include "../ssse3/enc_reshuffle.c"
 
-#endif	// __SSE4_2__
+#endif	// HAVE_SSE42
 
 BASE64_ENC_FUNCTION(sse42)
 {
-#ifdef __SSE4_2__
+#if HAVE_SSE42
 	#include "../generic/enc_head.c"
 	#include "../ssse3/enc_loop.c"
 	#include "../generic/enc_tail.c"
@@ -29,7 +29,7 @@ BASE64_ENC_FUNCTION(sse42)
 
 BASE64_DEC_FUNCTION(sse42)
 {
-#ifdef __SSE4_2__
+#if HAVE_SSE42
 	#include "../generic/dec_head.c"
 	#include "../ssse3/dec_loop.c"
 	#include "../generic/dec_tail.c"

--- a/lib/arch/ssse3/codec.c
+++ b/lib/arch/ssse3/codec.c
@@ -5,7 +5,7 @@
 #include "../../../include/libbase64.h"
 #include "../../codecs.h"
 
-#ifdef __SSSE3__
+#if HAVE_SSSE3
 #include <tmmintrin.h>
 
 #include "../sse2/compare_macros.h"
@@ -14,11 +14,11 @@
 #include "enc_reshuffle.c"
 #include "enc_translate.c"
 
-#endif	// __SSSE3__
+#endif	// HAVE_SSSE3
 
 BASE64_ENC_FUNCTION(ssse3)
 {
-#ifdef __SSSE3__
+#if HAVE_SSSE3
 	#include "../generic/enc_head.c"
 	#include "enc_loop.c"
 	#include "../generic/enc_tail.c"
@@ -29,7 +29,7 @@ BASE64_ENC_FUNCTION(ssse3)
 
 BASE64_DEC_FUNCTION(ssse3)
 {
-#ifdef __SSSE3__
+#if HAVE_SSSE3
 	#include "../generic/dec_head.c"
 	#include "dec_loop.c"
 	#include "../generic/dec_tail.c"


### PR DESCRIPTION
MSVC compiler does not define those `__SIMD__` (e.g. `__AVX__`) predefined macros. 

Conditional code is now only dependent on config.h values in all `codec.c` files except for NEON which also includes the same checks as in `codec_choose.c`.

This fixes mayeut/pybase64#8 and probably aklomp/base64#40