### PR TITLE
Allow unity builds

### DIFF
--- a/lib/arch/avx2/codec.c
+++ b/lib/arch/avx2/codec.c
@@ -8,12 +8,12 @@
 #if HAVE_AVX2
 #include <immintrin.h>
 
-#define CMPGT(s,n)	_mm256_cmpgt_epi8((s), _mm256_set1_epi8(n))
-#define CMPEQ(s,n)	_mm256_cmpeq_epi8((s), _mm256_set1_epi8(n))
-#define REPLACE(s,n)	_mm256_and_si256((s), _mm256_set1_epi8(n))
-#define RANGE(s,a,b)	_mm256_andnot_si256(CMPGT((s), (b)), CMPGT((s), (a) - 1))
+#define CMPGT256(s,n)	_mm256_cmpgt_epi8((s), _mm256_set1_epi8(n))
+#define CMPEQ256(s,n)	_mm256_cmpeq_epi8((s), _mm256_set1_epi8(n))
+#define REPLACE256(s,n)	_mm256_and_si256((s), _mm256_set1_epi8(n))
+#define RANGE256(s,a,b)	_mm256_andnot_si256(CMPGT256((s), (b)), CMPGT256((s), (a) - 1))
 
-static inline __m256i enc_reshuffle(const __m256i input) {
+static inline __m256i enc_reshuffle_256(const __m256i input) {
 	// translation from SSSE3 into AVX2 of procedure
 	// This one works with shifted (4 bytes) input in order to
 	// be able to work efficiently in the 2 128-bit lanes
@@ -95,7 +95,7 @@ static inline __m256i enc_reshuffle(const __m256i input) {
 }
 
 static inline __m256i
-enc_translate (const __m256i in)
+enc_translate_256 (const __m256i in)
 {
 	// LUT contains Absolute offset for all ranges:
 	const __m256i lut = _mm256_setr_epi8(65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0,
@@ -113,7 +113,7 @@ enc_translate (const __m256i in)
 	__m256i indices = _mm256_subs_epu8(in, _mm256_set1_epi8(51));
 
 	// mask is 0xFF (-1) for range #[1..4] and 0x00 for range #0:
-	__m256i mask = CMPGT(in, 25);
+	__m256i mask = CMPGT256(in, 25);
 
 	// substract -1, so add 1 to indices for range #[1..4], All indices are now correct:
 	indices = _mm256_sub_epi8(indices, mask);
@@ -125,7 +125,7 @@ enc_translate (const __m256i in)
 }
 
 static inline __m256i
-dec_reshuffle (__m256i in)
+dec_reshuffle_256 (__m256i in)
 {
 	// in, lower lane, bits, upper case are most significant bits, lower case are least significant bits:
 	// 00llllll 00kkkkLL 00jjKKKK 00JJJJJJ

--- a/lib/arch/avx2/dec_loop.c
+++ b/lib/arch/avx2/dec_loop.c
@@ -46,7 +46,7 @@ while (srclen >= 45)
 	str = _mm256_add_epi8(str, roll);
 
 	// Reshuffle the input to packed 12-byte output format:
-	str = dec_reshuffle(str);
+	str = dec_reshuffle_256(str);
 
 	// Store back:
 	_mm256_storeu_si256((__m256i *)o, str);

--- a/lib/arch/avx2/enc_loop.c
+++ b/lib/arch/avx2/enc_loop.c
@@ -8,12 +8,12 @@ if (srclen >= 32) {
 	// first load is done at c-0 not to get a segfault
 	__m256i inputvector = _mm256_loadu_si256((__m256i *)(c - 0));
 
-	// shift by 4 bytes, as required by enc_reshuffle
+	// shift by 4 bytes, as required by enc_reshuffle_256
 	inputvector = _mm256_permutevar8x32_epi32(inputvector, _mm256_setr_epi32(0, 0, 1, 2, 3, 4, 5, 6));
 
 	for (;;) {
-		inputvector = enc_reshuffle(inputvector);
-		inputvector = enc_translate(inputvector);
+		inputvector = enc_reshuffle_256(inputvector);
+		inputvector = enc_translate_256(inputvector);
 		_mm256_storeu_si256((__m256i *)o, inputvector);
 		c += 24;
 		o += 32;
@@ -21,7 +21,7 @@ if (srclen >= 32) {
 		if(srclen < 28) {
 			break;
 		}
-		// Load at c-4, as required by enc_reshuffle
+		// Load at c-4, as required by enc_reshuffle_256
 		inputvector = _mm256_loadu_si256((__m256i *)(c - 4));
 	}
 	outl += (size_t)(o - o_orig);

--- a/lib/arch/ssse3/dec_reshuffle.c
+++ b/lib/arch/ssse3/dec_reshuffle.c
@@ -1,3 +1,4 @@
+#pragma once
 static inline __m128i
 dec_reshuffle (__m128i in)
 {

--- a/lib/arch/ssse3/enc_reshuffle.c
+++ b/lib/arch/ssse3/enc_reshuffle.c
@@ -1,3 +1,4 @@
+#pragma once
 static inline __m128i
 enc_reshuffle (__m128i in)
 {

--- a/lib/arch/ssse3/enc_translate.c
+++ b/lib/arch/ssse3/enc_translate.c
@@ -1,3 +1,4 @@
+#pragma once
 static inline __m128i
 enc_translate (const __m128i in)
 {

--- a/lib/codecs.h
+++ b/lib/codecs.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "config.h"
 
 // Function parameters for encoding functions:


### PR DESCRIPTION
Thanks a lot for the library! I made [a Golang wrapper](https://github.com/myfreeweb/go-base64-simd), building C code into a single object file [like this](https://github.com/myfreeweb/go-base64-simd/blob/5b6f2d8a68850717af4bf539e0dc378bd1ca88d1/c/combo.c). This patch resolves name conflicts, allowing that kind of build to succeed.