### PR TITLE
chore: move x64 CI to GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  makefile-test:
+    name: makefile-${{ matrix.runner }}-amd64-${{ matrix.compiler }} ${{ ((matrix.openmp == 1) && '+openmp') || '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-18.04"]
+        compiler: ["gcc", "clang"]
+        openmp: ["0", "1"]
+        include:
+          - runner: "macos-11"
+            compiler: "clang"
+            openmp: "0"
+    env:
+      OPENMP: ${{ matrix.openmp }}
+      OMP_NUM_THREADS: ${{ ((matrix.openmp == 1) && '2') || '0' }}
+      CC: ${{ matrix.compiler }}
+      OBJCOPY: ${{ (startsWith(matrix.runner, 'macos') && 'echo') || 'objcopy' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: ./test/ci/amd64.sh
+
+  cmake-test:
+    name: cmake-${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-18.04", "macos-11", "windows-2019"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: CMake Configure
+        run: cmake -B out -DCMAKE_BUILD_TYPE=Release ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
+      - name: CMake Build
+        run: cmake --build out --config Release --verbose
+      - name: CTest
+        run: ctest --test-dir out -VV --build-config Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,9 @@ services: docker
 
 jobs:
   allow_failures:
-    - os: osx
     - arch: ppc64le
 
   include:
-    - name: linux-amd64-gcc
-      os: linux
-      arch: amd64
-      compiler: gcc
-      script: test/ci/amd64.sh
-
-    - name: linux-amd64-gcc +openmp
-      os: linux
-      arch: amd64
-      compiler: gcc
-      env: OPENMP=1 OMP_NUM_THREADS=4
-      script: test/ci/amd64.sh
-
-    - name: linux-amd64-clang
-      os: linux
-      arch: amd64
-      compiler: clang
-      script: test/ci/amd64.sh
-
     - name: linux-arm32-gcc
       compiler: gcc
       script: test/ci/docker-arm32.sh
@@ -63,9 +43,3 @@ jobs:
       arch: ppc64le
       compiler: gcc
       script: test/ci/generic.sh
-
-    - name: osx-amd64-clang
-      os: osx
-      arch: amd64
-      compiler: clang
-      script: test/ci/amd64.sh

--- a/cmake/Modules/TargetSIMDInstructionSet.cmake
+++ b/cmake/Modules/TargetSIMDInstructionSet.cmake
@@ -14,7 +14,7 @@
 ########################################################################
 # compiler flags definition
 macro(define_SIMD_compile_flags)
-    if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
         # x86
         set(COMPILE_FLAGS_SSSE3 "-mssse3")
         set(COMPILE_FLAGS_SSE41 "-msse4.1")

--- a/test/ci/amd64.sh
+++ b/test/ci/amd64.sh
@@ -5,10 +5,17 @@ export SSSE3_CFLAGS=-mssse3
 export SSE41_CFLAGS=-msse4.1
 export SSE42_CFLAGS=-msse4.2
 export AVX_CFLAGS=-mavx
-export AVX2_CFLAGS=-mavx2
+# no AVX2 on GHA macOS
+if [ "$(uname -s)" != "Darwin" ]; then
+	export AVX2_CFLAGS=-mavx2
+fi
+
+if [ "${OPENMP:-}" == "0" ]; then
+	unset OPENMP
+fi
 
 uname -a
-${TRAVIS_COMPILER} --version
+${CC} --version
 
 make
 make -C test


### PR DESCRIPTION
Travis CI does not offer free x64 CI for OpenSource projects anymore. Move to GitHub Actions for x64 tests.

Sample build is there: https://github.com/mayeut/base64/actions/runs/2323476527