### PR TITLE
fix: alpine gcc does not define _INTEGRAL_MAX_BITS/__WORDSIZE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.runner }}-amd64-${{ matrix.compiler }} ${{ ((matrix.openmp == 1) && '+openmp') || '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-20.04"]
+        compiler: ["gcc", "clang"]
+        openmp: ["0", "1"]
+        include:
+          - runner: "macos-11"
+            compiler: "clang"
+            openmp: "0"
+    env:
+      OPENMP: ${{ matrix.openmp }}
+      OMP_NUM_THREADS: ${{ ((matrix.openmp == 1) && '4') || '0' }}
+      CC: ${{ matrix.compiler }}
+      OBJCOPY: ${{ (startsWith(matrix.runner, 'macos') && 'echo') || 'objcopy' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: ./test/ci/amd64.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,17 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests
         run: ./test/ci/amd64.sh
+  test-alpine:
+    name: alpine-amd64-gcc
+    runs-on: ubuntu-20.04
+    container:
+      image: alpine:3.12
+      env:
+        CC: gcc
+    steps:
+      - name: Install deps
+        run: apk add --update bash build-base git
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: ./test/ci/amd64.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,9 @@ services: docker
 
 jobs:
   allow_failures:
-    - os: osx
     - arch: ppc64le
 
   include:
-    - name: linux-amd64-gcc
-      os: linux
-      arch: amd64
-      compiler: gcc
-      script: test/ci/amd64.sh
-
-    - name: linux-amd64-gcc +openmp
-      os: linux
-      arch: amd64
-      compiler: gcc
-      env: OPENMP=1 OMP_NUM_THREADS=4
-      script: test/ci/amd64.sh
-
-    - name: linux-amd64-clang
-      os: linux
-      arch: amd64
-      compiler: clang
-      script: test/ci/amd64.sh
-
     - name: linux-arm32-gcc
       compiler: gcc
       script: test/ci/docker-arm32.sh
@@ -63,9 +43,3 @@ jobs:
       arch: ppc64le
       compiler: gcc
       script: test/ci/generic.sh
-
-    - name: osx-amd64-clang
-      os: osx
-      arch: amd64
-      compiler: clang
-      script: test/ci/amd64.sh

--- a/lib/env.h
+++ b/lib/env.h
@@ -43,10 +43,14 @@
 #endif
 
 // Detect word size:
-#ifdef _INTEGRAL_MAX_BITS
+#if defined (_INTEGRAL_MAX_BITS)
 #  define BASE64_WORDSIZE _INTEGRAL_MAX_BITS
-#else
+#elif defined (__WORDSIZE)
 #  define BASE64_WORDSIZE __WORDSIZE
+#elif defined (__LONG_WIDTH__)
+#  define BASE64_WORDSIZE __LONG_WIDTH__
+#else
+#  error BASE64_WORDSIZE_NOT_DEFINED
 #endif
 
 // End-of-file definitions.

--- a/test/ci/amd64.sh
+++ b/test/ci/amd64.sh
@@ -5,10 +5,17 @@ export SSSE3_CFLAGS=-mssse3
 export SSE41_CFLAGS=-msse4.1
 export SSE42_CFLAGS=-msse4.2
 export AVX_CFLAGS=-mavx
-export AVX2_CFLAGS=-mavx2
+# no AVX2 on GHA macOS
+if [ "${OBJCOPY:-}" != "echo" ]; then
+	export AVX2_CFLAGS=-mavx2
+fi
+
+if [ "${OPENMP:-}" == "0" ]; then
+	unset OPENMP
+fi
 
 uname -a
-${TRAVIS_COMPILER} --version
+${CC} --version
 
 make
 make -C test


### PR DESCRIPTION
alpine gcc does not define `_INTEGRAL_MAX_BITS`/`__WORDSIZE`
This leads to `BASE64_WORDSIZE` being defined to `0`.
Fallback to `__LONG_WIDTH__` if it's defined or error out.

Builds on top of #75 