### PR TITLE
fix: alpine gcc does not define `_INTEGRAL_MAX_BITS`/`__WORDSIZE`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,38 @@ jobs:
         run: cmake --build out --config Release --verbose
       - name: CTest
         run: ctest --test-dir out -VV --build-config Release
+
+  alpine-makefile-test:
+    name: makefile-alpine-amd64-gcc
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.12
+      env:
+        CC: gcc
+    steps:
+      - name: Install deps
+        run: apk add --update bash build-base git
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: ./test/ci/amd64.sh
+
+  alpine-cmake-test:
+    name: cmake-alpine-amd64-gcc
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.12
+      env:
+        CC: gcc
+    steps:
+      - name: Install deps
+        run: apk add --update bash build-base cmake git
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: CMake Configure
+        run: cmake -B out -DCMAKE_BUILD_TYPE=Release ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
+      - name: CMake Build
+        run: cmake --build out --config Release --verbose
+      - name: CTest
+        run: ctest -VV --build-config Release
+        working-directory: ./out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  makefile-test:
+    name: makefile-${{ matrix.runner }}-amd64-${{ matrix.compiler }} ${{ ((matrix.openmp == 1) && '+openmp') || '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-18.04"]
+        compiler: ["gcc", "clang"]
+        openmp: ["0", "1"]
+        include:
+          - runner: "macos-11"
+            compiler: "clang"
+            openmp: "0"
+    env:
+      OPENMP: ${{ matrix.openmp }}
+      OMP_NUM_THREADS: ${{ ((matrix.openmp == 1) && '2') || '0' }}
+      CC: ${{ matrix.compiler }}
+      OBJCOPY: ${{ (startsWith(matrix.runner, 'macos') && 'echo') || 'objcopy' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: ./test/ci/amd64.sh
+
+  cmake-test:
+    name: cmake-${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-18.04", "macos-11", "windows-2019"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: CMake Configure
+        run: cmake -B out -DCMAKE_BUILD_TYPE=Release ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
+      - name: CMake Build
+        run: cmake --build out --config Release --verbose
+      - name: CTest
+        run: ctest --test-dir out -VV --build-config Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,9 @@ services: docker
 
 jobs:
   allow_failures:
-    - os: osx
     - arch: ppc64le
 
   include:
-    - name: linux-amd64-gcc
-      os: linux
-      arch: amd64
-      compiler: gcc
-      script: test/ci/amd64.sh
-
-    - name: linux-amd64-gcc +openmp
-      os: linux
-      arch: amd64
-      compiler: gcc
-      env: OPENMP=1 OMP_NUM_THREADS=4
-      script: test/ci/amd64.sh
-
-    - name: linux-amd64-clang
-      os: linux
-      arch: amd64
-      compiler: clang
-      script: test/ci/amd64.sh
-
     - name: linux-arm32-gcc
       compiler: gcc
       script: test/ci/docker-arm32.sh
@@ -63,9 +43,3 @@ jobs:
       arch: ppc64le
       compiler: gcc
       script: test/ci/generic.sh
-
-    - name: osx-amd64-clang
-      os: osx
-      arch: amd64
-      compiler: clang
-      script: test/ci/amd64.sh

--- a/cmake/Modules/TargetSIMDInstructionSet.cmake
+++ b/cmake/Modules/TargetSIMDInstructionSet.cmake
@@ -14,7 +14,7 @@
 ########################################################################
 # compiler flags definition
 macro(define_SIMD_compile_flags)
-    if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
         # x86
         set(COMPILE_FLAGS_SSSE3 "-mssse3")
         set(COMPILE_FLAGS_SSE41 "-msse4.1")

--- a/lib/env.h
+++ b/lib/env.h
@@ -43,10 +43,14 @@
 #endif
 
 // Detect word size:
-#ifdef _INTEGRAL_MAX_BITS
+#if defined(_INTEGRAL_MAX_BITS)
 #  define BASE64_WORDSIZE _INTEGRAL_MAX_BITS
-#else
+#elif defined(__WORDSIZE)
 #  define BASE64_WORDSIZE __WORDSIZE
+#elif defined (__LONG_WIDTH__)
+#  define BASE64_WORDSIZE __LONG_WIDTH__
+#else
+#  error BASE64_WORDSIZE_NOT_DEFINED
 #endif
 
 // End-of-file definitions.

--- a/test/ci/amd64.sh
+++ b/test/ci/amd64.sh
@@ -5,10 +5,17 @@ export SSSE3_CFLAGS=-mssse3
 export SSE41_CFLAGS=-msse4.1
 export SSE42_CFLAGS=-msse4.2
 export AVX_CFLAGS=-mavx
-export AVX2_CFLAGS=-mavx2
+# no AVX2 on GHA macOS
+if [ "$(uname -s)" != "Darwin" ]; then
+	export AVX2_CFLAGS=-mavx2
+fi
+
+if [ "${OPENMP:-}" == "0" ]; then
+	unset OPENMP
+fi
 
 uname -a
-${TRAVIS_COMPILER} --version
+${CC} --version
 
 make
 make -C test


### PR DESCRIPTION
alpine gcc does not define `_INTEGRAL_MAX_BITS`/`__WORDSIZE`
This leads to `BASE64_WORDSIZE` being defined to 0.
Fallback to `__LONG_WIDTH__` if it's defined or error out.

Builds on top of https://github.com/aklomp/base64/pull/75