### PR TITLE
Some fixes to cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@
 #     http://creativecommons.org/publicdomain/zero/1.0/
 #
 ########################################################################
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10.2)
+
+# new dependent option syntax. We are already compliant
+if (POLICY CMP0127)
+    cmake_policy(SET CMP0127 NEW) 
+endif()
 
 project(base64 LANGUAGES C VERSION 0.4.0)
 
@@ -42,7 +47,7 @@ cmake_dependent_option(BASE64_WITH_OpenMP "use OpenMP" OFF "OpenMP_FOUND" OFF)
 add_feature_info("OpenMP codec" BASE64_WITH_OpenMP "spreads codec work accross multiple threads")
 cmake_dependent_option(BASE64_REGENERATE_TABLES "regenerate the codec tables" OFF "NOT CMAKE_CROSSCOMPILING" OFF)
 
-set(_IS_X86 "\"${_TARGET_ARCH}\" STREQUAL \"x86\" OR \"${_TARGET_ARCH}\" STREQUAL \"x64\"")
+set(_IS_X86 "_TARGET_ARCH STREQUAL \"x86\" OR _TARGET_ARCH STREQUAL \"x64\"")
 cmake_dependent_option(BASE64_WITH_SSSE3 "add SSSE 3 codepath" ON ${_IS_X86} OFF)
 add_feature_info(SSSE3 BASE64_WITH_SSSE3 "add SSSE 3 codepath")
 cmake_dependent_option(BASE64_WITH_SSE41 "add SSE 4.1 codepath" ON ${_IS_X86} OFF)
@@ -54,11 +59,11 @@ add_feature_info(AVX BASE64_WITH_AVX "add AVX codepath")
 cmake_dependent_option(BASE64_WITH_AVX2 "add AVX 2 codepath" ON ${_IS_X86} OFF)
 add_feature_info(AVX2 BASE64_WITH_AVX2 "add AVX2 codepath")
 
-set(_IS_ARM "\"${_TARGET_ARCH}\" STREQUAL \"arm\"")
+set(_IS_ARM "_TARGET_ARCH STREQUAL \"arm\"")
 cmake_dependent_option(BASE64_WITH_NEON32 "add NEON32 codepath" OFF ${_IS_ARM} OFF)
 add_feature_info(NEON32 BASE64_WITH_NEON32 "add NEON32 codepath")
 
-set(_IS_ARM64 "\"${_TARGET_ARCH}\" STREQUAL \"arm64\"")
+set(_IS_ARM64 "_TARGET_ARCH STREQUAL \"arm64\"")
 cmake_dependent_option(BASE64_WITH_NEON64 "add NEON64 codepath" ON ${_IS_ARM64} OFF)
 add_feature_info(NEON64 BASE64_WITH_NEON64 "add NEON64 codepath")
 
@@ -181,7 +186,6 @@ define_SIMD_compile_flags()
 if (_TARGET_ARCH STREQUAL "x86" OR _TARGET_ARCH STREQUAL "x64")
     macro(configure_codec _TYPE)
         if (BASE64_WITH_${_TYPE})
-            message(STATUS "Add codec: lib/arch/${_DIR}/codec.c")
             string(TOLOWER "${_TYPE}" _DIR)
             set_source_files_properties("lib/arch/${_DIR}/codec.c" PROPERTIES
                 COMPILE_FLAGS "${COMPILE_FLAGS_${_TYPE}}"
@@ -220,11 +224,7 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/cmake/config.h.in" "${CMAKE_CURRENT_BI
 ########################################################################
 # OpenMP Settings
 if (BASE64_WITH_OpenMP)
-    target_compile_options(base64
-        PRIVATE
-            ${OpenMP_C_FLAGS}
-    )
-    target_link_libraries(base64 OpenMP::OpenMP_C)
+    target_link_libraries(base64 PRIVATE OpenMP::OpenMP_C)
 endif()
 
 ########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ if (BASE64_WITH_OpenMP)
         PRIVATE
             ${OpenMP_C_FLAGS}
     )
+    target_link_libraries(base64 OpenMP::OpenMP_C)
 endif()
 
 ########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,10 @@ if (BASE64_BUILD_TESTS)
 endif()
 
 ########################################################################
+# base64
+add_subdirectory(bin)
+
+########################################################################
 # cmake install
 install(DIRECTORY include/ TYPE INCLUDE)
 install(TARGETS base64 EXPORT base64-targets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set_package_properties(OpenMP PROPERTIES
 ########################################################################
 # Compilation options
 option(BASE64_WERROR "Treat warnings as error" ON)
-option(BASE64_BUILD_TESTS "add test projects" ON)
+option(BASE64_BUILD_TESTS "add test projects" OFF)
 cmake_dependent_option(BASE64_WITH_OpenMP "use OpenMP" OFF "OpenMP_FOUND" OFF)
 add_feature_info("OpenMP codec" BASE64_WITH_OpenMP "spreads codec work accross multiple threads")
 cmake_dependent_option(BASE64_REGENERATE_TABLES "regenerate the codec tables" OFF "NOT CMAKE_CROSSCOMPILING" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,14 @@ cmake_minimum_required(VERSION 3.10.2)
 
 # new dependent option syntax. We are already compliant
 if (POLICY CMP0127)
-    cmake_policy(SET CMP0127 NEW) 
+    cmake_policy(SET CMP0127 NEW)
 endif()
 
 project(base64 LANGUAGES C VERSION 0.4.0)
 
 include(GNUInstallDirs)
 include(CMakeDependentOption)
+include(CheckIncludeFile)
 include(FeatureSummary)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
@@ -29,6 +30,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 include(TargetArch)
 detect_target_architecture(_TARGET_ARCH)
 
+check_include_file(getopt.h HAVE_GETOPT_H)
+cmake_dependent_option(BASE64_BUILD_CLI "Build the cli for encoding and decoding" ON "HAVE_GETOPT_H" OFF)
+add_feature_info(CLI BASE64_BUILD_CLI "enables the CLI executable for encoding and decoding")
 
 ###################################################################
 # optional/conditional dependencies
@@ -235,12 +239,23 @@ endif()
 
 ########################################################################
 # base64
-add_subdirectory(bin)
+if (BASE64_BUILD_CLI)
+    add_executable(base64-bin
+        bin/base64.c
+    )
+    target_link_libraries(base64-bin PRIVATE base64)
+    set_target_properties(base64-bin PROPERTIES
+        OUTPUT_NAME base64
+    )
+endif()
 
 ########################################################################
 # cmake install
 install(DIRECTORY include/ TYPE INCLUDE)
-install(TARGETS base64 EXPORT base64-targets)
+install(TARGETS base64 EXPORT base64-targets DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if (BASE64_BUILD_CLI)
+    install(TARGETS base64-bin EXPORT base64-targets DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cmake/base64-config.cmake.in

--- a/README.md
+++ b/README.md
@@ -441,8 +441,8 @@ x86 processors
 | AMD E-450                                 | 645       | 564       | 625       | 634       | -       | -       | -        | -        |
 | Intel Edison @ 500 MHz                    | 79\*      | 92\*      | 152\*     | 172\*     | -       | -       | -        | -        |
 | Intel Edison @ 500 MHz OPENMP 2 thread    | 158\*     | 184\*     | 300\*     | 343\*     | -       | -       | -        | -        |
-| Intel Edison @ 500 MHz (x86-64)           | 97\*      | 146\*     | 197\*     | 207\*     | -       | -       | -        | -        |
-| Intel Edison @ 500 MHz (x86-64) 2 thread  | 193\*     | 288\*     | 389\*     | 410\*     | -       | -       | -        | -        |
+| Intel Edison @ 500 MHz (x86-64)           | 162       | 119       | 209       | 164       | -       | -       | -        | -        |
+| Intel Edison @ 500 MHz (x86-64) 2 thread  | 319       | 237       | 412       | 329       | -       | -       | -        | -        |
 
 ARM processors
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,5 @@
+# executable has same name as lib, see https://gist.github.com/jlgerber/eafc4ee2b9954e27dd2bb009496b1b03
+add_executable(base64-bin base64.c)
+target_link_libraries(base64-bin PRIVATE base64)
+install(TARGETS base64-bin DESTINATION bin)
+set_target_properties(base64-bin PROPERTIES OUTPUT_NAME base64)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,5 +1,0 @@
-# executable has same name as lib, see https://gist.github.com/jlgerber/eafc4ee2b9954e27dd2bb009496b1b03
-add_executable(base64-bin base64.c)
-target_link_libraries(base64-bin PRIVATE base64)
-install(TARGETS base64-bin DESTINATION bin)
-set_target_properties(base64-bin PROPERTIES OUTPUT_NAME base64)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,13 +16,14 @@ function(add_base64_test TEST_NAME)
     foreach(SRC_FILE ${ARGN})
         list(APPEND SRC_FILES "${SRC_FILE}")
     endforeach()
-    
+
     add_executable(${TEST_NAME} ${SRC_FILES})
     target_link_libraries(${TEST_NAME} PRIVATE base64)
-    
+
     add_test(NAME ${TEST_NAME}
         COMMAND ${TEST_NAME}
     )
+    install(TARGETS ${TEST_NAME} DESTINATION bin)
 endfunction()
 
 
@@ -41,3 +42,4 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(benchmark PRIVATE rt)
 endif()
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ function(add_base64_test TEST_NAME)
     add_test(NAME ${TEST_NAME}
         COMMAND ${TEST_NAME}
     )
-    install(TARGETS ${TEST_NAME} DESTINATION bin)
+    install(TARGETS ${TEST_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endfunction()
 
 


### PR DESCRIPTION
Hi,

Here are some fixes after the recent pull of cmake support.
- when enabling OpenMP also link against openmp lib, otherwise still not enabled
- not only build test tools but also install them (this is needed for Yocto recipe to pick them up and package)
- also build base64 command line encoder
- shutup warnings on recent versions of cmake (optional, @burn care to review this?)
- updated edison x86_64 benchmarks (optional)

My motherboard i7-4770 @ 3.4 GHz DDR1600 died, I won't be able to update these. I could provide a set on i7-10700 CPU @ 2.90GHz DDR4 3200?