### PR TITLE
fix(ci): cmake tests are not run on GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: CMake Configure
-        run: cmake -B out -DCMAKE_BUILD_TYPE=Release ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
+        run: >
+          cmake
+          -B out
+          -Werror=dev
+          -DBASE64_BUILD_TESTS=ON
+          ${{ runner.os != 'Windows' && '-DCMAKE_BUILD_TYPE=Release' || '' }}
+          ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
       - name: CMake Build
         run: cmake --build out --config Release --verbose
       - name: CTest
-        run: ctest --test-dir out -VV --build-config Release
+        run: ctest --no-tests=error --test-dir out -VV --build-config Release
 
   alpine-makefile-test:
     name: makefile-alpine-amd64-gcc
@@ -72,9 +78,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: CMake Configure
-        run: cmake -B out -DCMAKE_BUILD_TYPE=Release ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
+        run: cmake -B out -Werror=dev -DBASE64_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
       - name: CMake Build
         run: cmake --build out --config Release --verbose
       - name: CTest
-        run: ctest -VV --build-config Release
+        run: ctest --no-tests=error -VV --build-config Release
         working-directory: ./out


### PR DESCRIPTION
Following #79, tests were not run anymore with cmake builds (as tests were not built by default after that PR).
This PR re-enables testing cmake builds, adds `--no-tests=error` flag to `ctest` (would have caught the "no tests" == OK issue).
This also adds `-Werror=dev` to `cmake` configure step to check and enforce the effectiveness of #79 regarding the multiple warnings that were output by cmake before that.