### PR TITLE
Update word size detection

### DIFF
--- a/lib/env.h
+++ b/lib/env.h
@@ -43,12 +43,15 @@
 #endif
 
 // Detect word size:
-#if defined(_INTEGRAL_MAX_BITS)
+#if defined(__x86_64__) && defined(__ILP32__)
+// this is the way to detect x32 ABI per https://wiki.debian.org/X32Port
+#  define BASE64_WORDSIZE 64
+#elif defined(_INTEGRAL_MAX_BITS)
 #  define BASE64_WORDSIZE _INTEGRAL_MAX_BITS
 #elif defined(__WORDSIZE)
 #  define BASE64_WORDSIZE __WORDSIZE
-#elif defined (__LONG_WIDTH__)
-#  define BASE64_WORDSIZE __LONG_WIDTH__
+#elif defined (__SIZE_WIDTH__)
+#  define BASE64_WORDSIZE __SIZE_WIDTH__
 #else
 #  error BASE64_WORDSIZE_NOT_DEFINED
 #endif


### PR DESCRIPTION
The detection for word size was dependent on `__LONG_WIDTH__` for at least gcc Alpine Linux (probably other musl distros too).
This is not working with clang which does not define `__LONG_WIDTH__`.
Replace `__LONG_WIDTH__` by `__SIZE_WIDTH__`.
As this will not work as expected for x32 ABI, add a robust x32 detection first.