### PR TITLE
NEON64: enc: no inline asm for clang -O0

### DIFF
--- a/lib/arch/neon64/codec.c
+++ b/lib/arch/neon64/codec.c
@@ -18,8 +18,12 @@
 #include <arm_neon.h>
 
 // Only enable inline assembly on supported compilers.
-#if defined(__GNUC__) || defined(__clang__)
-#define BASE64_NEON64_USE_ASM
+#if defined(__clang__)
+#  if defined(__OPTIMIZE__)
+#    define BASE64_NEON64_USE_ASM
+#  endif
+#elif defined(__GNUC__)
+#  define BASE64_NEON64_USE_ASM
 #endif
 
 static inline uint8x16x4_t


### PR DESCRIPTION
This may not be the best fix, but it does allow compiling of debug builds with clang.

Also, as far as I can tell the NEON32 inline asm is not affected.

Fixes https://github.com/aklomp/base64/issues/96