### PR TITLE
Fix out-of-bounds access in test

### DIFF
--- a/test/test_base64.c
+++ b/test/test_base64.c
@@ -195,9 +195,14 @@ test_streaming (int flags)
 
 		base64_stream_decode_init(&state, flags);
 		memset(enc, 0, 400);
-		while (inpos < 400 && base64_stream_decode(&state, &ref[inpos], (inpos + bs > reflen) ? reflen - inpos : bs, &enc[enclen], &partlen)) {
+		while (base64_stream_decode(&state, &ref[inpos], (inpos + bs > reflen) ? reflen - inpos : bs, &enc[enclen], &partlen)) {
 			enclen += partlen;
 			inpos += bs;
+
+			// Has the entire buffer been consumed?
+			if (inpos >= 400) {
+				break;
+			}
 		}
 		if (enclen != 256) {
 			printf("FAIL: stream decoding gave incorrect size: "

--- a/test/test_base64.c
+++ b/test/test_base64.c
@@ -195,7 +195,7 @@ test_streaming (int flags)
 
 		base64_stream_decode_init(&state, flags);
 		memset(enc, 0, 400);
-		while (base64_stream_decode(&state, &ref[inpos], (inpos + bs > reflen) ? reflen - inpos : bs, &enc[enclen], &partlen)) {
+		while (inpos < 400 && base64_stream_decode(&state, &ref[inpos], (inpos + bs > reflen) ? reflen - inpos : bs, &enc[enclen], &partlen)) {
 			enclen += partlen;
 			inpos += bs;
 		}


### PR DESCRIPTION
When running the tests with address sanitizer enabled, it fails with the following error:

```
test/test_base64.c:198:40: runtime error: index 402 out of bounds for type 'char[400]'
    #0 0x7f322c00c749 in test_streaming test/test_base64.c:198:40
    #1 0x7f322c00c749 in test_one_codec test/test_base64.c:340:10
    #2 0x7f322c00c749 in main test/test_base64.c:361:11
```

I think adding this bounds check preserves the semantics of the test but I'm not super familiar with the codebase.