### PR TITLE
Fix i686 builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,26 @@ jobs:
         run: ./test/ci/test.sh
 
   cmake-test:
-    name: cmake-${{ matrix.runner }}
+    name: cmake-${{ matrix.runner }}-${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         runner: ["ubuntu-20.04", "macos-11", "windows-2019"]
+        platform: ["x86_64", "i686"]
+        exclude:
+          - runner: "macos-11"
+            platform: "i686"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install Ubuntu i686 support
+        if: runner.os == 'Linux' && matrix.platform == 'i686'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libc6-dev-i386
+          echo "CFLAGS=-m32" >> $GITHUB_ENV
+          echo "LDFLAGS=-m32" >> $GITHUB_ENV
       - name: CMake Configure
         run: >
           cmake
@@ -45,6 +56,7 @@ jobs:
           -DBASE64_BUILD_TESTS=ON
           ${{ runner.os != 'Windows' && '-DCMAKE_BUILD_TYPE=Release' || '' }}
           ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
+          ${{ runner.os == 'Windows' && matrix.platform == 'i686' && '-A Win32' || '' }}
           -DBASE64_WITH_AVX512=OFF
       - name: CMake Build
         run: cmake --build out --config Release --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ add_feature_info(AVX BASE64_WITH_AVX "add AVX codepath")
 cmake_dependent_option(BASE64_WITH_AVX2 "add AVX 2 codepath" ON ${_IS_X86} OFF)
 add_feature_info(AVX2 BASE64_WITH_AVX2 "add AVX2 codepath")
 cmake_dependent_option(BASE64_WITH_AVX512 "add AVX 512 codepath" ON ${_IS_X86} OFF)
-add_feature_info(AVX2 BASE64_WITH_AVX512 "add AVX512 codepath")
+add_feature_info(AVX512 BASE64_WITH_AVX512 "add AVX512 codepath")
 
 cmake_dependent_option(BASE64_WITH_NEON32 "add NEON32 codepath" OFF _TARGET_ARCH_arm OFF)
 add_feature_info(NEON32 BASE64_WITH_NEON32 "add NEON32 codepath")

--- a/lib/arch/avx/codec.c
+++ b/lib/arch/avx/codec.c
@@ -11,9 +11,9 @@
 #if HAVE_AVX
 #include <immintrin.h>
 
-// Only enable inline assembly on supported compilers.
+// Only enable inline assembly on supported compilers and on 64-bit CPUs.
 #ifndef BASE64_AVX_USE_ASM
-# if defined(__GNUC__) || defined(__clang__)
+# if (defined(__GNUC__) || defined(__clang__)) && BASE64_WORDSIZE == 64
 #  define BASE64_AVX_USE_ASM 1
 # else
 #  define BASE64_AVX_USE_ASM 0

--- a/lib/arch/avx2/codec.c
+++ b/lib/arch/avx2/codec.c
@@ -11,9 +11,9 @@
 #if HAVE_AVX2
 #include <immintrin.h>
 
-// Only enable inline assembly on supported compilers.
+// Only enable inline assembly on supported compilers and on 64-bit CPUs.
 #ifndef BASE64_AVX2_USE_ASM
-# if defined(__GNUC__) || defined(__clang__)
+# if (defined(__GNUC__) || defined(__clang__)) && BASE64_WORDSIZE == 64
 #  define BASE64_AVX2_USE_ASM 1
 # else
 #  define BASE64_AVX2_USE_ASM 0


### PR DESCRIPTION
Inline assembly builds are failing in 32-bit, only enable AVX/AVX2 inline assembly in 64-bit mode.
This was already done for SSE* codecs.
Add tests for 32-bit builds.
