### PR TITLE
Detect word size for Windows properly

### DIFF
--- a/lib/env.h
+++ b/lib/env.h
@@ -46,12 +46,18 @@
 #if defined (__x86_64__)
 // This also works for the x32 ABI, which has a 64-bit word size.
 #  define BASE64_WORDSIZE 64
-#elif defined (_INTEGRAL_MAX_BITS)
-#  define BASE64_WORDSIZE _INTEGRAL_MAX_BITS
 #elif defined (__WORDSIZE)
 #  define BASE64_WORDSIZE __WORDSIZE
 #elif defined (__SIZE_WIDTH__)
 #  define BASE64_WORDSIZE __SIZE_WIDTH__
+#elif defined (_WIN32)
+// _WIN32 is defined for all Windows targets but _WIN64 is only defined for
+// 64-bit targets.
+#  if defined (_WIN64)
+#    define BASE64_WORDSIZE 64
+#  else
+#    define BASE64_WORDSIZE 32
+#  endif
 #else
 #  error BASE64_WORDSIZE_NOT_DEFINED
 #endif


### PR DESCRIPTION
In Windows SDK the `_INTEGRAL_MAX_BITS` is always 64 even when building for x86_32 targets, so it should not be used for detecting word size when compiling for Windows.

Also `_INTEGRAL_MAX_BITS` means the max bits of integer, which does not necessarily equal to the word size, so it should be used as the last resort for detecting word size.

Currently compiling Node.js for 32bit Windows with clang breaks because of this.