### PR TITLE
fix: Detect platform word size based on `SIZE_MAX`

### DIFF
--- a/lib/env.h
+++ b/lib/env.h
@@ -1,6 +1,8 @@
 #ifndef BASE64_ENV_H
 #define BASE64_ENV_H
 
+#include <stdint.h>
+
 // This header file contains macro definitions that describe certain aspects of
 // the compile-time environment. Compatibility and portability macros go here.
 
@@ -46,12 +48,14 @@
 #if defined (__x86_64__)
 // This also works for the x32 ABI, which has a 64-bit word size.
 #  define BASE64_WORDSIZE 64
-#elif defined (_INTEGRAL_MAX_BITS)
-#  define BASE64_WORDSIZE _INTEGRAL_MAX_BITS
 #elif defined (__WORDSIZE)
 #  define BASE64_WORDSIZE __WORDSIZE
 #elif defined (__SIZE_WIDTH__)
 #  define BASE64_WORDSIZE __SIZE_WIDTH__
+#elif SIZE_MAX == 0xffffffff
+#  define BASE64_WORDSIZE 32
+#elif SIZE_MAX == 0xffffffffffffffff
+#  define BASE64_WORDSIZE 64
 #else
 #  error BASE64_WORDSIZE_NOT_DEFINED
 #endif


### PR DESCRIPTION
The native word size on a platform matches the size of `size_t` with a few rare exceptions like the x32 ABI on linux. Therefore we can derive a general cross platform value for `BASE64_WORDSIZE` based on `SIZE_MAX` which the C99 standard guarantees to be available and well defined.

This fixes the misdection of x86/arm32 win32 as a 64bit platform, i.e. it is an alternative to #123 
@mayeut I think this should also cover the `__WORDSIZE` and `__SIZE_WIDTH__` cases. Can you verify this? If that indeed is the case I would like remove those branches, too.

See also https://en.cppreference.com/w/c/types/limits