### PR TITLE
CI: add tests for various MSYS2 environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,3 +169,46 @@ jobs:
             echo "::group::CTest"
             ctest --no-tests=error --test-dir out -VV --build-config Release
             echo "::endgroup::CTest"
+
+  msys2-cmake-test:
+    name: msys2-cmake-${{ matrix.msystem }}
+    needs: makefile-analysis
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { msystem: msys, toolchain: "gcc" }
+          - { msystem: mingw32, env: mingw-w64-i686- }
+          - { msystem: mingw64, env: mingw-w64-x86_64- }
+          - { msystem: ucrt64, env: mingw-w64-ucrt-x86_64- }
+          - { msystem: clang32, env: mingw-w64-clang-i686- }
+          - { msystem: clang64, env: mingw-w64-clang-x86_64- }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup MSYS2 ${{matrix.msystem}}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.msystem}}
+          update: true
+          install: >-
+            make
+            ${{ matrix.env }}${{ matrix.toolchain || 'toolchain' }}
+            ${{ matrix.env }}cmake
+      - name: CMake Configure
+        shell: msys2 {0}
+        run: >
+          cmake
+          -B out
+          -Werror=dev
+          -DBASE64_BUILD_TESTS=ON
+          -DCMAKE_BUILD_TYPE=Release
+          -DBASE64_WITH_AVX512=OFF
+      - name: CMake Build
+        shell: msys2 {0}
+        run: cmake --build out --config Release --verbose
+      - name: CTest
+        shell: msys2 {0}
+        run: ctest --no-tests=error --test-dir out -VV --build-config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,3 +212,34 @@ jobs:
       - name: CTest
         shell: msys2 {0}
         run: ctest --no-tests=error --test-dir out -VV --build-config Release
+
+  msys2-makefile-test:
+    name: msys2-makefile-${{ matrix.msystem }}
+    needs: makefile-analysis
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { msystem: msys, toolchain: "gcc" }
+          - { msystem: mingw32, env: mingw-w64-i686- }
+          - { msystem: mingw64, env: mingw-w64-x86_64- }
+          - { msystem: ucrt64, env: mingw-w64-ucrt-x86_64- }
+          # - { msystem: clang32, env: mingw-w64-clang-i686- }  disabled, lld does not support the "-r" option
+          # - { msystem: clang64, env: mingw-w64-clang-x86_64- }  disabled, lld does not support the "-r" option
+    env:
+      CC: cc.exe
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup MSYS2 ${{matrix.msystem}}
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.msystem}}
+          update: true
+          install: >-
+            make
+            ${{ matrix.env }}${{ matrix.toolchain || 'toolchain' }}
+      - name: Run tests
+        shell: msys2 {0}
+        run: ./test/ci/test.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic
+CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic -DBASE64_STATIC_DEFINE
 
 # Set OBJCOPY if not defined by environment:
 OBJCOPY ?= objcopy
@@ -56,6 +56,8 @@ ifdef OPENMP
   CFLAGS += -fopenmp
 endif
 
+TARGET := $(shell $(CC) -dumpmachine)
+
 
 .PHONY: all analyze clean
 
@@ -64,9 +66,16 @@ all: bin/base64 lib/libbase64.o
 bin/base64: bin/base64.o lib/libbase64.o
 	$(CC) $(CFLAGS) -o $@ $^
 
-lib/libbase64.o: $(OBJS)
-	$(LD) -r -o $@ $^
-	$(OBJCOPY) --keep-global-symbols=lib/exports.txt $@
+lib/exports.build.txt: lib/exports.txt
+ifeq (i686-w64-mingw32, $(TARGET))
+	sed -e 's/^/_/' $< > $@
+else
+	cp -f $< $@
+endif
+
+lib/libbase64.o: lib/exports.build.txt $(OBJS)
+	$(LD) -r -o $@ $(OBJS)
+	$(OBJCOPY) --keep-global-symbols=$< $@
 
 lib/config.h:
 	@echo "#define HAVE_AVX512 $(HAVE_AVX512)"  > $@
@@ -97,4 +106,4 @@ analyze: clean
 	scan-build --use-analyzer=`which clang` --status-bugs make
 
 clean:
-	rm -f bin/base64 bin/base64.o lib/libbase64.o lib/config.h $(OBJS)
+	rm -f bin/base64 bin/base64.o lib/libbase64.o lib/config.h lib/exports.build.txt $(OBJS)

--- a/bin/base64.c
+++ b/bin/base64.c
@@ -1,4 +1,19 @@
-#define _XOPEN_SOURCE		// IOV_MAX
+// Test for MinGW.
+#if defined(__MINGW32__) || defined(__MINGW64__)
+# define MINGW
+#endif
+
+// Decide if the writev(2) system call needs to be emulated as a series of
+// write(2) calls. At least MinGW does not support writev(2).
+#ifdef MINGW
+# define EMULATE_WRITEV
+#endif
+
+// Include the necessary system header when using the system's writev(2).
+#ifndef EMULATE_WRITEV
+# define _XOPEN_SOURCE		// Unlock IOV_MAX
+# include <sys/uio.h>
+#endif
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -8,7 +23,7 @@
 #include <getopt.h>
 #include <errno.h>
 #include <limits.h>
-#include <sys/uio.h>
+
 #include "../include/libbase64.h"
 
 // Size of the buffer for the "raw" (not base64-encoded) data in bytes.
@@ -49,6 +64,59 @@ struct buffer {
 	// Runtime-allocated buffer for base64-encoded data.
 	char *enc;
 };
+
+// Optionally emulate writev(2) as a series of write calls.
+#ifdef EMULATE_WRITEV
+
+// Quick and dirty definition of IOV_MAX as it is probably not defined.
+#ifndef IOV_MAX
+# define IOV_MAX 1024
+#endif
+
+// Quick and dirty definition of this system struct, for local use only.
+struct iovec {
+
+	// Opaque data pointer.
+	void *iov_base;
+
+	// Length of the data in bytes.
+	size_t iov_len;
+};
+
+static ssize_t
+writev (const int fd, const struct iovec *iov, int iovcnt)
+{
+	ssize_t r, nwrite = 0;
+
+	// Reset the error marker.
+	errno = 0;
+
+	while (iovcnt-- > 0) {
+
+		// Write the vector; propagate errors back to the caller. Note
+		// that this loses information about how much vectors have been
+		// successfully written, but that also seems to be the case
+		// with the real function. The API is somewhat flawed.
+		if ((r = write(fd, iov->iov_base, iov->iov_len)) < 0) {
+			return r;
+		}
+
+		// Update the total write count.
+		nwrite += r;
+
+		// Return early after a partial write; the caller should retry.
+		if ((size_t) r != iov->iov_len) {
+			break;
+		}
+
+		// Move to the next vector.
+		iov++;
+	}
+
+	return nwrite;
+}
+
+#endif	// EMULATE_WRITEV
 
 static bool
 buffer_alloc (const struct config *config, struct buffer *buf)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,12 @@
-CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic
+CFLAGS += -std=c99 -O3 -Wall -Wextra -pedantic -DBASE64_STATIC_DEFINE
 ifdef OPENMP
   CFLAGS += -fopenmp
 endif
 
 TARGET := $(shell $(CC) -dumpmachine)
 ifneq (, $(findstring darwin, $(TARGET)))
+  BENCH_LDFLAGS=
+else ifneq (, $(findstring mingw, $(TARGET)))
   BENCH_LDFLAGS=
 else
   # default to linux, -lrt needed
@@ -15,7 +17,9 @@ endif
 
 test: clean test_base64 benchmark
 	./test_base64
+ifeq (, $(findstring mingw, $(TARGET)))  # no "/dev/urandom" on Windows
 	./benchmark
+endif
 
 valgrind: clean test_base64
 	valgrind --error-exitcode=2 ./test_base64


### PR DESCRIPTION
This PR adds CI tests for various MSYS2 environments (msys, mingw64, clang32 & clang64).

It's based on top of 17a9ab9b4ad1e6bf759282788745619a2abe5c0a and also adds a fix for mingw makefile builds.

Resolves https://github.com/aklomp/base64/issues/127.