### PR TITLE
refactor: Remove detection logic subsumed by `SIZE_MAX` checks

### DIFF
--- a/lib/env.h
+++ b/lib/env.h
@@ -48,10 +48,6 @@
 #if defined (__x86_64__)
 // This also works for the x32 ABI, which has a 64-bit word size.
 #  define BASE64_WORDSIZE 64
-#elif defined (__WORDSIZE)
-#  define BASE64_WORDSIZE __WORDSIZE
-#elif defined (__SIZE_WIDTH__)
-#  define BASE64_WORDSIZE __SIZE_WIDTH__
 #elif SIZE_MAX == UINT32_MAX
 #  define BASE64_WORDSIZE 32
 #elif SIZE_MAX == UINT64_MAX


### PR DESCRIPTION
@aklomp as per https://github.com/aklomp/base64/pull/125#issuecomment-1881039242