### PR TITLE
fix: Set active CP to UTF-8 on Windows 10 and 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,6 +212,13 @@ jobs:
       - name: CTest
         shell: msys2 {0}
         run: ctest --no-tests=error --test-dir out -VV --build-config Release
+      - name: Test demo utility with unicode filenames and file contents on Windows
+        shell: msys2 {0}
+        run: |
+          out/bin/base64 test/ci/😵‍💫.bin > test/ci/😵‍💫.bin.b64
+          out/bin/base64 -d test/ci/😵‍💫.bin.b64 > test/ci/😵‍💫.bin
+          cd test/ci
+          sha256sum -c checksums.txt
 
   msys2-makefile-test:
     name: msys2-makefile-${{ matrix.msystem }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,10 @@ if (BASE64_BUILD_CLI)
     set_target_properties(base64-bin PROPERTIES
         OUTPUT_NAME base64
     )
+
+    if (WIN32)
+      target_sources(base64-bin PRIVATE bin/base64.rc)
+    endif ()
 endif()
 
 ########################################################################

--- a/bin/base64.manifest
+++ b/bin/base64.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+	<assemblyIdentity type="win32" name="base64" version="0.5.2.0" />
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+		<security>
+			<requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+				<requestedExecutionLevel level="asInvoker" uiAccess="false" />
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!-- Windows 10 and Windows 11 -->
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+		</application>
+	</compatibility>
+	<application>
+		<windowsSettings>
+			<activeCodePage
+				xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+		</windowsSettings>
+	</application>
+</assembly>

--- a/bin/base64.rc
+++ b/bin/base64.rc
@@ -1,0 +1,2 @@
+#include "winuser.h"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "base64.manifest"

--- a/test/ci/.gitattributes
+++ b/test/ci/.gitattributes
@@ -1,0 +1,2 @@
+😵‍💫.bin binary -text
+checksums.txt text eol=lf

--- a/test/ci/checksums.txt
+++ b/test/ci/checksums.txt
@@ -1,0 +1,1 @@
+4cd842ba8dce30216f77d2d5bf8a648e2dba6d95be5b12884f81e55bfab7b3cc *😵‍💫.bin

--- a/test/ci/😵‍💫.bin
+++ b/test/ci/😵‍💫.bin
@@ -1,0 +1,2 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+😵‍💫


### PR DESCRIPTION
This notably allows passing unicode filenames as commandline arguments to the demo utility `bin/base64` without them being mangled in case the unicode filename cannot be represented in the currently active system code page.

Note that this only works/takes effect on Windows 10 Version 1903 and later. This is only integrated with CMake as I don't know how to portably invoke the resource compiler in a Makefile. I also added a test case for the CI.

See-Also: https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page

Resolves #138 