### PR TITLE
fix: typo in macro _AVX_512_ENABLED_BY_OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Install analysis tools"
         run: |
           sudo apt-get update
@@ -27,7 +27,7 @@ jobs:
         compiler: ["gcc", "clang"]
         openmp: ["0", "1"]
         include:
-          - runner: "macos-11"
+          - runner: "macos-12"
             compiler: "clang"
             openmp: "0"
     env:
@@ -37,7 +37,7 @@ jobs:
       OBJCOPY: ${{ (startsWith(matrix.runner, 'macos') && 'echo') || 'objcopy' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         run: ./test/ci/test.sh
 
@@ -48,14 +48,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["ubuntu-20.04", "macos-11", "windows-2019"]
+        runner: ["ubuntu-20.04", "windows-2019"]
         platform: ["x86_64", "i686"]
-        exclude:
-          - runner: "macos-11"
-            platform: "i686"
+        include:
+          - runner: "macos-12"
+            platform: "x86_64"
+          - runner: "macos-14"
+            platform: "arm64"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Ubuntu i686 support
         if: runner.os == 'Linux' && matrix.platform == 'i686'
         run: |
@@ -70,7 +72,6 @@ jobs:
           -Werror=dev
           -DBASE64_BUILD_TESTS=ON
           ${{ runner.os != 'Windows' && '-DCMAKE_BUILD_TYPE=Release' || '' }}
-          ${{ runner.os == 'macOS' && '-DBASE64_WITH_AVX2=OFF' || '' }}
           ${{ runner.os == 'Windows' && matrix.platform == 'i686' && '-A Win32' || '' }}
           -DBASE64_WITH_AVX512=OFF
       - name: CMake Build
@@ -90,7 +91,7 @@ jobs:
       - name: Install deps
         run: apk add --update bash build-base git
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         run: ./test/ci/test.sh
 
@@ -104,7 +105,7 @@ jobs:
       - name: Install deps
         run: apk add --update bash build-base cmake git
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: CMake Configure
         run: >
           cmake
@@ -130,7 +131,7 @@ jobs:
         cc: [gcc, clang]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{matrix.arch}}
@@ -151,7 +152,7 @@ jobs:
         cc: [gcc, clang]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{matrix.arch}}
@@ -187,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup MSYS2 ${{matrix.msystem}}
         uses: msys2/setup-msys2@v2
         with:
@@ -238,7 +239,7 @@ jobs:
       CC: cc.exe
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup MSYS2 ${{matrix.msystem}}
         uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,11 +73,12 @@ jobs:
           -DBASE64_BUILD_TESTS=ON
           ${{ runner.os != 'Windows' && '-DCMAKE_BUILD_TYPE=Release' || '' }}
           ${{ runner.os == 'Windows' && matrix.platform == 'i686' && '-A Win32' || '' }}
-          -DBASE64_WITH_AVX512=OFF
       - name: CMake Build
         run: cmake --build out --config Release --verbose
       - name: CTest
         run: ctest --no-tests=error --test-dir out -VV --build-config Release
+        env:
+          BASE64_TEST_SKIP_AVX512: "1"
 
   alpine-makefile-test:
     name: makefile-alpine-amd64-gcc
@@ -112,13 +113,14 @@ jobs:
           -B out
           -Werror=dev
           -DBASE64_BUILD_TESTS=ON
-          -DBASE64_WITH_AVX512=OFF
           -DCMAKE_BUILD_TYPE=Release
       - name: CMake Build
         run: cmake --build out --config Release --verbose
       - name: CTest
         run: ctest --no-tests=error -VV --build-config Release
         working-directory: ./out
+        env:
+          BASE64_TEST_SKIP_AVX512: "1"
 
   alpine-alt-arch-makefile-test:
     name: makefile-alpine-${{matrix.arch}}-${{matrix.cc}}
@@ -206,13 +208,14 @@ jobs:
           -Werror=dev
           -DBASE64_BUILD_TESTS=ON
           -DCMAKE_BUILD_TYPE=Release
-          -DBASE64_WITH_AVX512=OFF
       - name: CMake Build
         shell: msys2 {0}
         run: cmake --build out --config Release --verbose
       - name: CTest
         shell: msys2 {0}
         run: ctest --no-tests=error --test-dir out -VV --build-config Release
+        env:
+          BASE64_TEST_SKIP_AVX512: "1"
       - name: Test demo utility with unicode filenames and file contents on Windows
         shell: msys2 {0}
         run: |

--- a/lib/codec_choose.c
+++ b/lib/codec_choose.c
@@ -82,7 +82,7 @@
 
 #define _XCR_XMM_AND_YMM_STATE_ENABLED_BY_OS (bit_XMM | bit_YMM)
 
-#define _AVX_512_ENABLED_BY_OS (bit_XMM | bit_YMM | bit_OPMASK | bit_ZMM | bit bit_HIGH_ZMM)
+#define _AVX_512_ENABLED_BY_OS (bit_XMM | bit_YMM | bit_OPMASK | bit_ZMM | bit_HIGH_ZMM)
 
 #endif
 

--- a/test/benchmark.c
+++ b/test/benchmark.c
@@ -271,10 +271,12 @@ main ()
 			sizes[i].label, sizes[i].repeat, sizes[i].batch);
 
 		// Loop over all codecs:
-		for (size_t j = 0; codecs[j]; j++)
-			if (codec_supported(1 << j))
-				codec_bench(&b, &sizes[i], codecs[j], 1 << j);
-	};
+		for (size_t j = 0; codecs[j]; j++) {
+			int flags = codec_supported(j);
+			if (flags)
+				codec_bench(&b, &sizes[i], codecs[j], flags);
+		}
+	}
 
 	// Free memory:
 err2:	free(b.enc);

--- a/test/ci/analysis.sh
+++ b/test/ci/analysis.sh
@@ -15,8 +15,9 @@ for USE_ASSEMBLY in 0 1; do
 		export SSE42_CFLAGS="-msse4.2 -DBASE64_SSE42_USE_ASM=${USE_ASSEMBLY}"
 		export AVX_CFLAGS="-mavx -DBASE64_AVX_USE_ASM=${USE_ASSEMBLY}"
 		export AVX2_CFLAGS="-mavx2 -DBASE64_AVX2_USE_ASM=${USE_ASSEMBLY}"
+		export AVX512_CFLAGS="-mavx512vl -mavx512vbmi"
 		# Temporarily disable AVX512; it is not available in CI yet.
-		# export AVX512_CFLAGS="-mavx512vl -mavx512vbmi"
+		export BASE64_TEST_SKIP_AVX512=1
 	elif [ "${MACHINE}" == "aarch64" ]; then
 		export NEON64_CFLAGS="-march=armv8-a"
 	elif [ "${MACHINE}" == "armv7l" ]; then

--- a/test/ci/test.sh
+++ b/test/ci/test.sh
@@ -7,12 +7,10 @@ if [ "${MACHINE}" == "x86_64" ]; then
 	export SSE41_CFLAGS=-msse4.1
 	export SSE42_CFLAGS=-msse4.2
 	export AVX_CFLAGS=-mavx
-	# no AVX2 or AVX512 on GHA macOS
-	if [ "$(uname -s)" != "Darwin" ]; then
-		export AVX2_CFLAGS=-mavx2
-		# Temporarily disable AVX512; it is not available in CI yet.
-		# export AVX512_CFLAGS="-mavx512vl -mavx512vbmi"
-	fi
+	export AVX2_CFLAGS=-mavx2
+	export AVX512_CFLAGS="-mavx512vl -mavx512vbmi"
+	# Temporarily disable AVX512; it is not available in CI yet.
+	export BASE64_TEST_SKIP_AVX512=1
 elif [ "${MACHINE}" == "aarch64" ]; then
 	export NEON64_CFLAGS="-march=armv8-a"
 elif [ "${MACHINE}" == "armv7l" ]; then

--- a/test/codec_supported.c
+++ b/test/codec_supported.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../include/libbase64.h"
@@ -18,12 +20,21 @@ static char *_codecs[] =
 char **codecs = _codecs;
 
 int
-codec_supported (int flags)
+codec_supported (size_t index)
 {
+	if (index >= (sizeof(_codecs) / sizeof(_codecs[0])) - 1) {
+		return 0;
+	}
 	// Check if given codec is supported by trying to decode a test string:
 	char *a = "aGVsbG8=";
 	char b[10];
 	size_t outlen;
-
-	return (base64_decode(a, strlen(a), b, &outlen, flags) != -1);
+	char envVariable[32];
+	sprintf(envVariable, "BASE64_TEST_SKIP_%s", _codecs[index]);
+	const char* envOverride = getenv(envVariable);
+	if ((envOverride != NULL) && (strcmp(envOverride, "1") == 0)) {
+		return 0;
+	}
+	int flags = 1 << index;
+	return (base64_decode(a, strlen(a), b, &outlen, flags) != -1) ? flags : 0;
 }

--- a/test/codec_supported.h
+++ b/test/codec_supported.h
@@ -1,3 +1,3 @@
 extern char **codecs;
 
-int codec_supported (int flags);
+int codec_supported (size_t index);

--- a/test/test_base64.c
+++ b/test/test_base64.c
@@ -313,14 +313,16 @@ test_invalid_dec_input (int flags)
 }
 
 static int
-test_one_codec (const char *codec, int flags)
+test_one_codec (size_t codec_index)
 {
 	bool fail = false;
+	const char *codec = codecs[codec_index];
 
 	printf("Codec %s:\n", codec);
 
 	// Skip if this codec is not supported:
-	if (!codec_supported(flags)) {
+	int flags = codec_supported(codec_index);
+	if (flags == 0) {
 		puts("  skipping");
 		return false;
 	}
@@ -376,12 +378,8 @@ main ()
 
 	// Loop over all codecs:
 	for (size_t i = 0; codecs[i]; i++) {
-
-		// Flags to invoke this codec:
-		int codec_flags = (1 << i);
-
 		// Test this codec, merge the results:
-		fail |= test_one_codec(codecs[i], codec_flags);
+		fail |= test_one_codec(i);
 	}
 
 	return (fail) ? 1 : 0;


### PR DESCRIPTION
The typo results in a build error when AVX512 is enabled.
This should have been caught by CI but CI disables things that can't be tested: rework CI & tests to build everything and skip tests that can't be run.
We could probably add a test using Intel SDE in order to test everything but that would be for another PR.

based on #144 which fixes the CI workflow.

fixes #146
fixes #147